### PR TITLE
feat: user manage + web-push subscriptions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "next-auth": "^4.24.11",
         "node-fetch": "^3.3.2",
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "web-push": "^3.6.7"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -1574,6 +1575,14 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -1809,6 +1818,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -1934,6 +1954,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/bn.js": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
+      "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw=="
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -1996,6 +2021,11 @@
       "engines": {
         "node": ">=16.20.1"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
     },
     "node_modules/call-bind": {
       "version": "1.0.8",
@@ -2401,6 +2431,14 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.222",
@@ -3510,6 +3548,26 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/http_ece": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http_ece/-/http_ece-1.2.0.tgz",
+      "integrity": "sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3543,6 +3601,11 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -4080,6 +4143,25 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "dependencies": {
+        "jwa": "^2.0.0",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/kareem": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.6.3.tgz",
@@ -4244,6 +4326,11 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -4260,7 +4347,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -5278,6 +5364,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -5310,6 +5415,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/scheduler": {
       "version": "0.26.0",
@@ -6303,6 +6413,24 @@
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/web-push": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/web-push/-/web-push-3.6.7.tgz",
+      "integrity": "sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==",
+      "dependencies": {
+        "asn1.js": "^5.3.0",
+        "http_ece": "1.2.0",
+        "https-proxy-agent": "^7.0.0",
+        "jws": "^4.0.0",
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "web-push": "src/cli.js"
+      },
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/web-streams-polyfill": {

--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack",
-    "build": "next build --turbopack",
+  "dev": "next dev --turbopack",
+  "prebuild": "node scripts/ensure-vapid.js",
+  "build": "next build --turbopack",
     "start": "next start",
     "lint": "eslint"
   },
@@ -17,7 +18,8 @@
     "next-auth": "^4.24.11",
     "node-fetch": "^3.3.2",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "web-push": "^3.6.7"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,17 @@
+self.addEventListener('push', function(event) {
+  let data = {};
+  if (event.data) {
+    data = event.data.json();
+  }
+  const title = data.title || 'AIOgames';
+  const options = {
+    body: data.body || '',
+    data: data
+  };
+  event.waitUntil(self.registration.showNotification(title, options));
+});
+
+self.addEventListener('notificationclick', function(event) {
+  event.notification.close();
+  event.waitUntil(clients.openWindow('/'));
+});

--- a/scripts/ensure-vapid.js
+++ b/scripts/ensure-vapid.js
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const child = require('child_process');
+
+function envHas(key) {
+  // Check both process.env and .env.local
+  if (process.env[key]) return true;
+  const envPath = path.resolve(process.cwd(), '.env.local');
+  if (!fs.existsSync(envPath)) return false;
+  const contents = fs.readFileSync(envPath, 'utf8');
+  const re = new RegExp(`^${key}=`, 'm');
+  return re.test(contents);
+}
+
+function runGenerate() {
+  console.log('VAPID keys missing. Generating new VAPID keys and writing to .env.local...');
+  const script = path.resolve(process.cwd(), 'scripts', 'generate-vapid.js');
+  child.execSync(`node "${script}" --write`, { stdio: 'inherit' });
+}
+
+if (!envHas('VAPID_PUBLIC_KEY') || !envHas('VAPID_PRIVATE_KEY')) {
+  runGenerate();
+} else {
+  console.log('VAPID keys already present. Skipping generation.');
+}

--- a/scripts/generate-vapid.js
+++ b/scripts/generate-vapid.js
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+/*
+ * Simple helper to generate VAPID keys for web-push
+ * Usage:
+ *   node scripts/generate-vapid.js        # prints keys
+ *   node scripts/generate-vapid.js --write  # writes/updates .env.local
+ */
+
+const fs = require('fs');
+const path = require('path');
+const webpush = require('web-push');
+
+function generate() {
+  return webpush.generateVAPIDKeys();
+}
+
+function writeEnv(publicKey, privateKey) {
+  const envPath = path.resolve(process.cwd(), '.env.local');
+  let contents = '';
+  if (fs.existsSync(envPath)) contents = fs.readFileSync(envPath, 'utf8');
+
+  const setOrReplace = (key, value, input) => {
+    const re = new RegExp(`^${key}=.*$`, 'm');
+    if (re.test(input)) {
+      return input.replace(re, `${key}=${value}`);
+    }
+    return input + (input && !input.endsWith('\n') ? '\n' : '') + `${key}=${value}\n`;
+  };
+
+  contents = setOrReplace('VAPID_PUBLIC_KEY', publicKey, contents);
+  contents = setOrReplace('VAPID_PRIVATE_KEY', privateKey, contents);
+
+  fs.writeFileSync(envPath, contents, 'utf8');
+  console.log(`Wrote VAPID keys to ${envPath}`);
+}
+
+function main() {
+  const keys = generate();
+  console.log('VAPID keys generated:');
+  console.log(JSON.stringify(keys, null, 2));
+  console.log('\nAdd these to your environment as:');
+  console.log(`VAPID_PUBLIC_KEY=${keys.publicKey}`);
+  console.log(`VAPID_PRIVATE_KEY=${keys.privateKey}`);
+
+  if (process.argv.includes('--write')) {
+    writeEnv(keys.publicKey, keys.privateKey);
+  }
+}
+
+main();

--- a/src/app/api/notifications/send-test/route.ts
+++ b/src/app/api/notifications/send-test/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '../../auth/[...nextauth]/route';
+import connectDB from '../../../../lib/db';
+import { User } from '../../../../lib/models';
+import webpush from 'web-push';
+
+// Ensure VAPID keys are configured via env
+const VAPID_PUBLIC = process.env.VAPID_PUBLIC_KEY;
+const VAPID_PRIVATE = process.env.VAPID_PRIVATE_KEY;
+
+if (VAPID_PUBLIC && VAPID_PRIVATE) {
+  webpush.setVapidDetails('mailto:admin@example.com', VAPID_PUBLIC, VAPID_PRIVATE);
+}
+
+export async function POST() {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    if (!VAPID_PUBLIC || !VAPID_PRIVATE) {
+      return NextResponse.json({ error: 'VAPID keys not configured' }, { status: 500 });
+    }
+
+    await connectDB();
+    const user = await User.findById(session.user.id);
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const subs = user.pushSubscriptions || [];
+    const payload = JSON.stringify({ title: 'Test notification', body: 'This is a test push notification from AIOgames.' });
+
+    const results = [];
+    for (const sub of subs) {
+      try {
+        await webpush.sendNotification(sub, payload);
+        results.push({ endpoint: sub.endpoint, success: true });
+      } catch (e) {
+        console.error('Push send error for', sub.endpoint, e);
+        results.push({ endpoint: sub.endpoint, success: false, error: String(e) });
+      }
+    }
+
+    return NextResponse.json({ results });
+  } catch (error) {
+    console.error('POST /api/notifications/send-test error', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/app/api/notifications/vapid-public/route.ts
+++ b/src/app/api/notifications/vapid-public/route.ts
@@ -1,0 +1,6 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  const key = process.env.VAPID_PUBLIC_KEY || '';
+  return NextResponse.json({ publicKey: key });
+}

--- a/src/app/api/user/delete/route.ts
+++ b/src/app/api/user/delete/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '../../auth/[...nextauth]/route';
+import connectDB from '../../../../lib/db';
+import { User, TrackedGame } from '../../../../lib/models';
+
+export async function DELETE() {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    await connectDB();
+
+    // Soft delete: deactivate user and their tracked games. If you want full deletion, change accordingly.
+    const user = await User.findById(session.user.id);
+    if (!user) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    }
+
+    user.isActive = false;
+    await user.save();
+
+    await TrackedGame.updateMany({ userId: user._id }, { isActive: false });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('DELETE /api/user/delete error', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/app/api/user/me/route.ts
+++ b/src/app/api/user/me/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '../../auth/[...nextauth]/route';
+import connectDB from '../../../../lib/db';
+import { User } from '../../../../lib/models';
+
+export async function GET() {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    await connectDB();
+    const user = await User.findById(session.user.id).select('email name role preferences');
+    if (!user) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    }
+
+    return NextResponse.json({
+      id: user._id.toString(),
+      email: user.email,
+      name: user.name,
+      role: user.role,
+      preferences: user.preferences || {}
+    });
+  } catch (error) {
+    console.error('GET /api/user/me error', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/app/api/user/subscribe/route.ts
+++ b/src/app/api/user/subscribe/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '../../auth/[...nextauth]/route';
+import connectDB from '../../../../lib/db';
+import { User } from '../../../../lib/models';
+
+export async function POST(req: Request) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const body = await req.json();
+    const subscription = body.subscription;
+    if (!subscription || !subscription.endpoint) {
+      return NextResponse.json({ error: 'Invalid subscription' }, { status: 400 });
+    }
+
+    await connectDB();
+    const user = await User.findById(session.user.id);
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    // Avoid duplicates by endpoint
+    user.pushSubscriptions = user.pushSubscriptions || [];
+  const exists = user.pushSubscriptions.some((s: { endpoint?: string }) => s.endpoint === subscription.endpoint);
+    if (!exists) {
+      user.pushSubscriptions.push(subscription);
+      await user.save();
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('POST /api/user/subscribe error', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/app/user/manage/page.tsx
+++ b/src/app/user/manage/page.tsx
@@ -1,0 +1,320 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+export default function UserManagePage() {
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+
+  const [form, setForm] = useState({
+    email: '',
+    currentPassword: '',
+    newPassword: '',
+    confirmNewPassword: '',
+    // placeholder for notification settings
+    notificationsProvider: '',
+    webpushEnabled: true
+  });
+
+  const router = useRouter();
+
+  useEffect(() => {
+    let mounted = true;
+    async function load() {
+      setLoading(true);
+      try {
+        const res = await fetch('/api/user/me');
+        if (!res.ok) throw new Error('Failed to load user');
+        const data = await res.json();
+        if (!mounted) return;
+        setForm((f) => ({ ...f, email: data.email || '' }));
+        // initialize notification settings from preferences if available
+        if (data.preferences?.notifications) {
+          setForm((f) => ({
+            ...f,
+            notificationsProvider: data.preferences.notifications.provider || f.notificationsProvider,
+            webpushEnabled: typeof data.preferences.notifications.webpushEnabled === 'boolean' ? data.preferences.notifications.webpushEnabled : f.webpushEnabled
+          }));
+          // If provider is webpush and enabled, prompt for permission
+          if ((data.preferences.notifications.provider === 'webpush' || !data.preferences.notifications.provider) && data.preferences.notifications.webpushEnabled !== false) {
+            // prompt after a tick to avoid blocking render
+                    setTimeout(() => {
+                      if (Notification && Notification.permission === 'default') {
+                        // request permission non-blocking
+                        void Notification.requestPermission();
+                      }
+                    }, 500);
+          }
+        }
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        setError(message || 'Unable to load user');
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    }
+    load();
+    return () => { mounted = false; };
+  }, []);
+
+  // Register service worker and subscribe if webpush enabled
+  useEffect(() => {
+    async function setupPush() {
+      if (!('serviceWorker' in navigator) || !('PushManager' in window)) return;
+      try {
+        // register service worker
+        const reg = await navigator.serviceWorker.register('/sw.js');
+
+        // fetch VAPID public key
+        const r = await fetch('/api/notifications/vapid-public');
+        if (!r.ok) return;
+        const { publicKey } = await r.json();
+        if (!publicKey) return;
+
+        // subscribe if permission is default and user wants webpush
+        if (form.notificationsProvider === 'webpush' && form.webpushEnabled) {
+          if (Notification.permission === 'default') {
+            // request permission first
+            const perm = await Notification.requestPermission();
+            if (perm !== 'granted') return;
+          }
+
+          if (Notification.permission === 'granted') {
+            const sub = await reg.pushManager.subscribe({
+              userVisibleOnly: true,
+              applicationServerKey: urlBase64ToUint8Array(publicKey)
+            });
+
+            // send subscription to backend
+            await fetch('/api/user/subscribe', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ subscription: sub })
+            });
+          }
+        }
+          } catch {
+        // ignore errors during push setup
+      }
+    }
+
+    setupPush();
+  }, [form.notificationsProvider, form.webpushEnabled]);
+
+  // helper: convert base64 public key to Uint8Array
+  function urlBase64ToUint8Array(base64String: string) {
+    const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+    const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+    const rawData = atob(base64);
+    const outputArray = new Uint8Array(rawData.length);
+    for (let i = 0; i < rawData.length; ++i) {
+      outputArray[i] = rawData.charCodeAt(i);
+    }
+    return outputArray;
+  }
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+    const { name, value } = e.target as HTMLInputElement | HTMLSelectElement;
+    setForm({ ...form, [name]: value });
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    setSuccess('');
+
+    if (form.newPassword && form.newPassword !== form.confirmNewPassword) {
+      setError('New passwords do not match');
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const payload: { email: string; currentPassword?: string; newPassword?: string; provider?: string; webpushEnabled?: boolean } = { email: form.email };
+      if (form.newPassword) {
+        payload.currentPassword = form.currentPassword;
+        payload.newPassword = form.newPassword;
+      }
+      payload.provider = form.notificationsProvider;
+      payload.webpushEnabled = form.webpushEnabled;
+
+      const res = await fetch('/api/user/update', {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(payload)
+      });
+
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data?.error || 'Update failed');
+      } else {
+        setSuccess('Profile updated');
+        // clear password fields
+        setForm((f) => ({ ...f, currentPassword: '', newPassword: '', confirmNewPassword: '' }));
+      }
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      setError(message || 'Update failed');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return <div className="p-8">Loading...</div>;
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-100 dark:bg-gray-900 p-6 flex items-start justify-center">
+      <div className="max-w-2xl w-full bg-white dark:bg-gray-800 rounded-lg shadow p-6">
+        <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">Manage Account</h1>
+        <p className="text-sm text-gray-600 dark:text-gray-300 mt-1">Update your email, change password, and configure notification options (coming soon).</p>
+
+        <form className="mt-6 space-y-6" onSubmit={handleSubmit}>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">Email</label>
+            <input
+              name="email"
+              type="email"
+              value={form.email}
+              onChange={handleChange}
+              required
+              className="mt-1 block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">Current Password (required to change password)</label>
+            <input
+              name="currentPassword"
+              type="password"
+              value={form.currentPassword}
+              onChange={handleChange}
+              className="mt-1 block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+            />
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">New Password</label>
+              <input
+                name="newPassword"
+                type="password"
+                value={form.newPassword}
+                onChange={handleChange}
+                className="mt-1 block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">Confirm New Password</label>
+              <input
+                name="confirmNewPassword"
+                type="password"
+                value={form.confirmNewPassword}
+                onChange={handleChange}
+                className="mt-1 block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+              />
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">Notification Provider (placeholder)</label>
+            <div className="flex items-center space-x-3">
+              <select
+                name="notificationsProvider"
+                value={form.notificationsProvider}
+                onChange={handleChange}
+                className="mt-1 block w-1/2 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+              >
+                <option value="webpush">Web Push</option>
+                <option value="email">Email</option>
+              </select>
+              <label className="flex items-center space-x-2 text-sm">
+                <input
+                  type="checkbox"
+                  name="webpushEnabled"
+                  checked={form.webpushEnabled}
+                  onChange={(e) => setForm({ ...form, webpushEnabled: e.target.checked })}
+                  className="w-4 h-4"
+                />
+                <span className="text-sm text-gray-600 dark:text-gray-300">Enable Web Push</span>
+              </label>
+            </div>
+          </div>
+
+          <div className="pt-4 border-t">
+            <h2 className="text-lg font-medium text-gray-900 dark:text-white">Danger Zone</h2>
+            <p className="text-sm text-gray-600 dark:text-gray-300">Delete your account — this will deactivate your account and tracked games.</p>
+            <div className="mt-3">
+              <button
+                type="button"
+                onClick={async () => {
+                  if (!confirm('Are you sure you want to delete your account? This action cannot be undone.')) return;
+                  try {
+                    const res = await fetch('/api/user/delete', { method: 'DELETE' });
+                    const data = await res.json();
+                    if (!res.ok) {
+                      alert(data?.error || 'Failed to delete account');
+                      return;
+                    }
+                    // Redirect to home after deletion
+                    window.location.href = '/';
+                  } catch {
+                    alert('Failed to delete account');
+                  }
+                }}
+                className="px-4 py-2 bg-red-600 text-white rounded-md"
+              >
+                Delete Account
+              </button>
+            </div>
+          </div>
+
+          {error && <div className="text-sm text-red-600 dark:text-red-300">{error}</div>}
+          {success && <div className="text-sm text-green-600 dark:text-green-300">{success}</div>}
+
+          <div className="flex items-center space-x-3">
+            <button
+              type="submit"
+              disabled={saving}
+              className="px-4 py-2 bg-blue-600 text-white rounded-md disabled:opacity-50"
+            >
+              {saving ? 'Saving...' : 'Save Changes'}
+            </button>
+            <button
+              type="button"
+              className="px-4 py-2 bg-green-600 text-white rounded-md"
+              onClick={async () => {
+                try {
+                  const res = await fetch('/api/notifications/send-test', { method: 'POST' });
+                  const data = await res.json();
+                  if (!res.ok) {
+                    alert(data?.error || 'Failed to send test notification');
+                    return;
+                  }
+                  alert('Test notification sent (check your device)');
+            } catch {
+            alert('Failed to send test notification');
+              }
+              }}
+            >
+              Send Test Notification
+            </button>
+            <button
+              type="button"
+              className="px-4 py-2 border rounded-md"
+              onClick={() => router.push('/')}
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -14,6 +14,7 @@ export function Navigation() {
     { href: '/', label: '🏠 Home', description: 'Main Dashboard' },
     { href: '/tracking', label: '📊 Tracking', description: 'Your Games' },
     ...(isAdmin ? [{ href: '/admin', label: '⚙️ Admin', description: 'Admin Panel' }] : []),
+    ...(session ? [{ href: '/user/manage', label: '👤 Account', description: 'Manage your account' }] : []),
   ];
 
   return (

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -48,6 +48,15 @@ const userSchema = new mongoose.Schema({
         type: Boolean,
         default: true
       },
+      provider: {
+        type: String,
+        enum: ['email', 'webpush'],
+        default: 'webpush'
+      },
+      webpushEnabled: {
+        type: Boolean,
+        default: true
+      },
       updateFrequency: {
         type: String,
         enum: ['immediate', 'daily', 'weekly'],
@@ -70,6 +79,13 @@ const userSchema = new mongoose.Schema({
       }
     }
   },
+  pushSubscriptions: [{
+    endpoint: String,
+    keys: {
+      p256dh: String,
+      auth: String
+    }
+  }],
   isActive: {
     type: Boolean,
     default: true

--- a/src/types/web-push.d.ts
+++ b/src/types/web-push.d.ts
@@ -1,0 +1,1 @@
+declare module 'web-push';


### PR DESCRIPTION
Adds a user account manage page, web-push subscription support, delete account endpoint, and automated VAPID generation on build.\n\nFiles: user manage page, API routes for subscribe/me/update/delete, service worker, web-push send-test, and scripts to generate/ensure VAPID keys.