### PR TITLE
fix(gameapi): raise per-site fetch timeout to 60s and fix UND_ERR_CONNECT_TIMEOUT

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,32 @@ TELEGRAM_BOT_TOKEN=your-telegram-bot-token-from-botfather
 # 🛡️ FlareSolverr (Cloudflare bypass for skidrow/steamrip)
 FLARESOLVERR_URL=http://flaresolverr:8191/v1
 
+# ⏱️ Network timeouts for outbound game-source scraping
+# Per-site HTTP request ceiling (milliseconds) — applies to every direct
+# fetch against skidrow/steamrip/dodi/online-fix/freegog/gamedrive/…
+# Default 60000 (60s) so a single slow TLS handshake or Cloudflare
+# challenge doesn't fail the whole search with the old 10s undici cap.
+# SITE_FETCH_TIMEOUT_MS=60000
+# TCP connect timeout for the global undici dispatcher used by `fetch()`.
+# This is what was silently hard-capped at 10s and caused
+# UND_ERR_CONNECT_TIMEOUT in logs. Raise or lower in ms as needed.
+# SITE_CONNECT_TIMEOUT_MS=60000
+# SITE_HEADERS_TIMEOUT_MS=60000
+# SITE_BODY_TIMEOUT_MS=60000
+# FlareSolverr request timeout (ms). FlareSolverr renders a browser to
+# solve CF challenges, which can easily take >30s on a cold session.
+# FLARE_TIMEOUT_MS=60000
+# FLARE_RETRIES=2
+
+# 🔌 Circuit breaker tuning for Skidrow / DODI
+# How long the circuit stays open after the failure threshold is reached.
+# SKIDROW_COOLDOWN_MS=60000
+# DODI_COOLDOWN_MS=60000
+# How many consecutive failures trip the breaker. Defaults to 2 so a single
+# transient blip doesn't block the site for the whole cooldown.
+# SKIDROW_FAILURE_THRESHOLD=2
+# DODI_FAILURE_THRESHOLD=2
+
 # 📦 Environment use development .env if youre developing!!
 NODE_ENV=production
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "next-auth": "^4.24.11",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "undici": "^7.25.0",
         "zod": "^4.1.12"
       },
       "devDependencies": {
@@ -10042,6 +10043,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "next-auth": "^4.24.11",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "undici": "^7.25.0",
     "zod": "^4.1.12"
   },
   "devDependencies": {

--- a/src/lib/gameapi/helpers.js
+++ b/src/lib/gameapi/helpers.js
@@ -3,6 +3,14 @@
  * Shared logic for Vercel and Docker deployments
  */
 
+// NOTE: `./net` (installed in index.ts) sets an undici global dispatcher
+// that raises the TCP connect timeout for the raw `fetch()` calls in this
+// module. Without that, every site fetch was silently capped at undici's 10s
+// default, which is what was making a single slow TLS handshake fail the
+// whole search with UND_ERR_CONNECT_TIMEOUT. Timings below assume the
+// dispatcher is already active; the module entry point always imports it
+// before any helpers here get called.
+
 // Cache configuration
 export const CACHE_CONFIG = {
   CACHE_TTL: 3600, // 1 hour
@@ -11,9 +19,56 @@ export const CACHE_CONFIG = {
   RECENT_UPLOADS_KEY: 'recent-uploads-complete',
 };
 
-// FlareSolverr timeout/retry settings (ms)
-export const DEFAULT_FLARE_TIMEOUT_MS = 30000; // 30s default
-export const DEFAULT_FLARE_RETRIES = 2;
+// Per-site HTTP timeout used for raw `fetch()` calls that talk directly to
+// an external source (skidrow/steamrip/dodi/onlinefix/freegog/gamedrive/…).
+// This is the end-to-end ceiling for a single request. Defaults to 60s so a
+// single slow TLS handshake / Cloudflare challenge won't fail the whole
+// search; the previous behaviour relied on undici's 10s connect timeout,
+// which the user repeatedly hit.
+export const SITE_FETCH_TIMEOUT_MS = Math.max(
+  10000,
+  parseInt(process.env.SITE_FETCH_TIMEOUT_MS || '60000', 10) || 60000
+);
+
+// FlareSolverr timeout/retry settings (ms). FlareSolverr itself renders a
+// browser to solve Cloudflare challenges, which can easily take >30s, so
+// default to 60s and cap individual callers at 60s as well (they used to cap
+// at 25s which guaranteed failures on cold solves).
+export const DEFAULT_FLARE_TIMEOUT_MS = Math.max(
+  10000,
+  parseInt(process.env.FLARE_TIMEOUT_MS || '60000', 10) || 60000
+);
+export const DEFAULT_FLARE_RETRIES = Math.max(
+  1,
+  parseInt(process.env.FLARE_RETRIES || '2', 10) || 2
+);
+
+/**
+ * Thin wrapper around fetch() that enforces `SITE_FETCH_TIMEOUT_MS` as a hard
+ * end-to-end timeout, in addition to undici's (now 60s) connect timeout. Any
+ * existing `signal` on the caller is composed with the timeout.
+ */
+export function siteFetch(resource, options = {}, timeoutMs = SITE_FETCH_TIMEOUT_MS) {
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
+  const userSignal = options.signal;
+  let signal = timeoutSignal;
+  if (userSignal) {
+    // AbortSignal.any is available on Node 20+; fall back to combining
+    // listeners for older runtimes.
+    if (typeof AbortSignal.any === 'function') {
+      signal = AbortSignal.any([timeoutSignal, userSignal]);
+    } else {
+      const controller = new AbortController();
+      const abort = (reason) => controller.abort(reason);
+      if (userSignal.aborted) abort(userSignal.reason);
+      else userSignal.addEventListener('abort', () => abort(userSignal.reason), { once: true });
+      if (timeoutSignal.aborted) abort(timeoutSignal.reason);
+      else timeoutSignal.addEventListener('abort', () => abort(timeoutSignal.reason), { once: true });
+      signal = controller.signal;
+    }
+  }
+  return fetch(resource, { ...options, signal });
+}
 
 // Cookie storage for SteamRip and Skidrow (in-memory for this instance)
 let steamripCookie = {
@@ -37,7 +92,15 @@ let dodiCookie = {
   expires_at: 0
 };
 
-const SKIDROW_COOLDOWN_MS = Math.max(30000, parseInt(process.env.SKIDROW_COOLDOWN_MS || '300000', 10) || 300000);
+// Circuit breakers. Previously a single network hiccup (a timeout on one
+// /api/games/search) would open the circuit for a full 5 minutes and make
+// every subsequent search silently skip that site. With per-site fetch
+// timeouts now at 60s (not 10s) and the undici connect timeout raised, one
+// failure is almost always a transient blip — we now require two consecutive
+// failures before opening, and default the cooldown to 60s. Env overrides
+// let operators retune without a code change.
+const SKIDROW_COOLDOWN_MS = Math.max(10000, parseInt(process.env.SKIDROW_COOLDOWN_MS || '60000', 10) || 60000);
+const SKIDROW_FAILURE_THRESHOLD = Math.max(1, parseInt(process.env.SKIDROW_FAILURE_THRESHOLD || '2', 10) || 2);
 let skidrowCircuit = {
   cooldownUntil: 0,
   failures: 0,
@@ -51,8 +114,12 @@ function isSkidrowCircuitOpen() {
 function noteSkidrowFailure(error) {
   skidrowCircuit.failures += 1;
   skidrowCircuit.lastError = String(error?.message || error || 'unknown error');
-  skidrowCircuit.cooldownUntil = Date.now() + SKIDROW_COOLDOWN_MS;
-  console.warn(`Skidrow circuit opened for ${Math.round(SKIDROW_COOLDOWN_MS / 1000)}s after failure #${skidrowCircuit.failures}: ${skidrowCircuit.lastError}`);
+  if (skidrowCircuit.failures >= SKIDROW_FAILURE_THRESHOLD) {
+    skidrowCircuit.cooldownUntil = Date.now() + SKIDROW_COOLDOWN_MS;
+    console.warn(`Skidrow circuit opened for ${Math.round(SKIDROW_COOLDOWN_MS / 1000)}s after failure #${skidrowCircuit.failures}: ${skidrowCircuit.lastError}`);
+  } else {
+    console.warn(`Skidrow fetch failure #${skidrowCircuit.failures}/${SKIDROW_FAILURE_THRESHOLD} (circuit still closed): ${skidrowCircuit.lastError}`);
+  }
 }
 
 function resetSkidrowCircuit() {
@@ -67,7 +134,8 @@ function resetSkidrowCircuit() {
 }
 
 // DODI circuit breaker (same pattern as Skidrow)
-const DODI_COOLDOWN_MS = Math.max(30000, parseInt(process.env.DODI_COOLDOWN_MS || '300000', 10) || 300000);
+const DODI_COOLDOWN_MS = Math.max(10000, parseInt(process.env.DODI_COOLDOWN_MS || '60000', 10) || 60000);
+const DODI_FAILURE_THRESHOLD = Math.max(1, parseInt(process.env.DODI_FAILURE_THRESHOLD || '2', 10) || 2);
 let dodiCircuit = {
   cooldownUntil: 0,
   failures: 0,
@@ -81,8 +149,12 @@ function isDodiCircuitOpen() {
 function noteDodiFailure(error) {
   dodiCircuit.failures += 1;
   dodiCircuit.lastError = String(error?.message || error || 'unknown error');
-  dodiCircuit.cooldownUntil = Date.now() + DODI_COOLDOWN_MS;
-  console.warn(`DODI circuit opened for ${Math.round(DODI_COOLDOWN_MS / 1000)}s after failure #${dodiCircuit.failures}: ${dodiCircuit.lastError}`);
+  if (dodiCircuit.failures >= DODI_FAILURE_THRESHOLD) {
+    dodiCircuit.cooldownUntil = Date.now() + DODI_COOLDOWN_MS;
+    console.warn(`DODI circuit opened for ${Math.round(DODI_COOLDOWN_MS / 1000)}s after failure #${dodiCircuit.failures}: ${dodiCircuit.lastError}`);
+  } else {
+    console.warn(`DODI fetch failure #${dodiCircuit.failures}/${DODI_FAILURE_THRESHOLD} (circuit still closed): ${dodiCircuit.lastError}`);
+  }
 }
 
 function resetDodiCircuit() {
@@ -408,7 +480,7 @@ export async function fetchSteamrip(url, isPageRequest = false) {
     const userAgent = isPageRequest ? 'GameSearch-API-v2-PageFetch/2.0' : 'GameSearch-API-v2/2.0';
 
     // Try direct fetch first (like skidrow) — avoids FlareSolverr delay when CF is not active
-    let response = await fetch(url, {
+    let response = await siteFetch(url, {
       headers: {
         'User-Agent': userAgent,
         'Accept': 'application/json, text/plain, */*',
@@ -444,7 +516,7 @@ export async function fetchSteamrip(url, isPageRequest = false) {
       const cookieUserAgent = cookie.userAgent || userAgent;
       const cookieString = cookie.cookies.join('; ');
 
-      response = await fetch(url, {
+      response = await siteFetch(url, {
         headers: {
           'User-Agent': cookieUserAgent,
           'Cookie': cookieString,
@@ -480,7 +552,7 @@ export async function fetchSteamrip(url, isPageRequest = false) {
         const freshUserAgent = freshCookie.userAgent || userAgent;
         const freshCookieString = freshCookie.cookies.join('; ');
 
-        const retryResponse = await fetch(url, {
+        const retryResponse = await siteFetch(url, {
           headers: {
             'User-Agent': freshUserAgent,
             'Cookie': freshCookieString,
@@ -535,7 +607,7 @@ export async function getFreshSkidrowCookie() {
     }
     
     const attempts = Math.max(1, parseInt(process.env.FLARE_RETRIES || '1', 10) || 1);
-    const timeoutMs = Math.min(25000, parseInt(process.env.FLARE_TIMEOUT_MS || DEFAULT_FLARE_TIMEOUT_MS, 10) || DEFAULT_FLARE_TIMEOUT_MS);
+    const timeoutMs = DEFAULT_FLARE_TIMEOUT_MS;
 
     // Ask FlareSolverr to request the Skidrow REST API endpoint (wp-json)
     // Requesting the actual API endpoint (instead of the site root) often
@@ -634,7 +706,7 @@ export async function getFreshDodiCookie() {
     }
 
     const attempts = Math.max(1, parseInt(process.env.FLARE_RETRIES || '1', 10) || 1);
-    const timeoutMs = Math.min(25000, parseInt(process.env.FLARE_TIMEOUT_MS || DEFAULT_FLARE_TIMEOUT_MS, 10) || DEFAULT_FLARE_TIMEOUT_MS);
+    const timeoutMs = DEFAULT_FLARE_TIMEOUT_MS;
 
     const response = await retryableFetch(flaresolverrUrl, {
       method: 'POST',
@@ -718,7 +790,7 @@ export async function fetchViaFlaresolverr(url, session = 'default') {
   const flaresolverrUrl = process.env.FLARESOLVERR_URL;
   if (!flaresolverrUrl) return null;
 
-  const timeoutMs = Math.min(25000, parseInt(process.env.FLARE_TIMEOUT_MS || DEFAULT_FLARE_TIMEOUT_MS, 10) || DEFAULT_FLARE_TIMEOUT_MS);
+  const timeoutMs = DEFAULT_FLARE_TIMEOUT_MS;
 
   try {
     console.log(`Fetching via FlareSolverr: ${url}`);
@@ -828,7 +900,7 @@ export async function fetchSkidrow(url, isPageRequest = false) {
     const userAgent = isPageRequest ? 'GameSearch-API-v2-PageFetch/2.0' : 'GameSearch-API-v2/2.0';
 
     // Try direct fetch first
-    let response = await fetch(url, {
+    let response = await siteFetch(url, {
       headers: {
         'User-Agent': userAgent,
         'Accept': 'application/json, text/plain, */*',
@@ -878,7 +950,7 @@ export async function fetchSkidrow(url, isPageRequest = false) {
         const cookieUserAgent = cookie.userAgent || userAgent;
         const cookieString = cookie.cookies.join('; ');
         
-        response = await fetch(url, {
+        response = await siteFetch(url, {
           headers: {
             'User-Agent': cookieUserAgent,
             'Cookie': cookieString,
@@ -965,7 +1037,7 @@ export async function fetchDodi(url, isPageRequest = false) {
       const cookieString = dodiCookie.cookies.join('; ');
       const cookieUserAgent = dodiCookie.userAgent || 'GameSearch-API-v2/2.0';
       try {
-        const cookieResponse = await fetch(url, {
+        const cookieResponse = await siteFetch(url, {
           headers: {
             'User-Agent': cookieUserAgent,
             'Cookie': cookieString,
@@ -993,7 +1065,7 @@ export async function fetchDodi(url, isPageRequest = false) {
     const userAgent = isPageRequest ? 'GameSearch-API-v2-PageFetch/2.0' : 'GameSearch-API-v2/2.0';
 
     // Try direct fetch first
-    let response = await fetch(url, {
+    let response = await siteFetch(url, {
       headers: {
         'User-Agent': userAgent,
         'Accept': 'application/json, text/plain, */*',
@@ -1050,7 +1122,7 @@ export async function fetchDodi(url, isPageRequest = false) {
           const cookieString = cookie.cookies.join('; ');
 
           // Try primary domain with cookies
-          let cookieResponse = await fetch(url, {
+          let cookieResponse = await siteFetch(url, {
             headers: {
               'User-Agent': cookieUserAgent,
               'Cookie': cookieString,
@@ -1082,7 +1154,7 @@ export async function fetchDodi(url, isPageRequest = false) {
 
           // Try fallback domain with cookies
           if (fallbackUrl !== url) {
-            cookieResponse = await fetch(fallbackUrl, {
+            cookieResponse = await siteFetch(fallbackUrl, {
               headers: {
                 'User-Agent': cookieUserAgent,
                 'Cookie': cookieString,
@@ -1249,7 +1321,7 @@ export async function extractDownloadLinksForV2(postUrl, siteType = 'skidrow', w
       } else if (siteType === 'dodi') {
         response = await fetchDodi(postUrl, true);
       } else {
-        response = await fetch(postUrl, {
+        response = await siteFetch(postUrl, {
           headers: {
             'User-Agent': 'Game-Search-API-v2-Link-Extractor/2.0'
           }
@@ -1815,7 +1887,7 @@ function buildOnlineFixPost({ id, title, link, date, image, description, excerpt
  * Fetch recently uploaded Online-Fix entries from RSS.
  */
 export async function fetchOnlineFixRecent() {
-  const response = await fetch(`${ONLINE_FIX_BASE}/rss.xml`, {
+  const response = await siteFetch(`${ONLINE_FIX_BASE}/rss.xml`, {
     headers: { 'User-Agent': 'GameSearch-API-v2/2.0', 'Accept': 'application/xml,text/xml;q=0.9,*/*;q=0.8' }
   });
   if (!response.ok) {
@@ -1862,7 +1934,7 @@ export async function fetchOnlineFixRecent() {
  */
 export async function fetchOnlineFixSearch(searchQuery) {
   const url = `${ONLINE_FIX_BASE}/index.php?do=search&subaction=search&story=${encodeURIComponent(searchQuery)}`;
-  const response = await fetch(url, {
+  const response = await siteFetch(url, {
     headers: { 'User-Agent': 'GameSearch-API-v2/2.0', 'Accept': 'text/html,*/*;q=0.8' }
   });
   if (!response.ok) {
@@ -1924,7 +1996,7 @@ export async function fetchOnlineFixSearch(searchQuery) {
  */
 export async function fetchGogGamesRecent() {
   const url = `${GOG_GAMES_BASE}/api/web/recent-torrents`;
-  const response = await fetch(url, {
+  const response = await siteFetch(url, {
     headers: { 'User-Agent': 'GameSearch-API-v2/2.0', 'Accept': 'application/json' }
   });
   if (!response.ok) {

--- a/src/lib/gameapi/index.ts
+++ b/src/lib/gameapi/index.ts
@@ -4,6 +4,13 @@
  * as direct function calls instead of HTTP requests.
  */
 
+// Side-effect import: installs the undici global dispatcher with a 60s+
+// TCP connect timeout before any raw `fetch()` runs against the external
+// sites. This replaces the undici default (10s) that was causing
+// `UND_ERR_CONNECT_TIMEOUT` whenever a piracy/release site was slow to
+// accept a TLS connection.
+import './net';
+
 import {
   SITE_CONFIGS as _SITE_CONFIGS,
   MAX_POSTS_PER_SITE as _MAX_POSTS_PER_SITE,
@@ -16,6 +23,7 @@ import {
   transformGogGamesPost,
   fetchOnlineFixRecent,
   fetchOnlineFixSearch,
+  siteFetch,
 } from './helpers.js';
 
 // Cast JS module exports to proper types
@@ -122,7 +130,7 @@ async function searchSite(siteConfig: SiteConfig, searchQuery: string): Promise<
     } else if (siteConfig.type === 'dodi') {
       response = await fetchDodi(url);
     } else {
-      response = await fetch(url, {
+      response = await siteFetch(url, {
         headers: { 'User-Agent': 'GameSearch-API-v2/2.0' }
       });
     }
@@ -177,7 +185,7 @@ async function fetchRecentFromSite(siteConfig: SiteConfig): Promise<TransformedP
     } else if (siteConfig.type === 'dodi') {
       response = await fetchDodi(url);
     } else {
-      response = await fetch(url, {
+      response = await siteFetch(url, {
         headers: { 'User-Agent': 'GameSearch-API-v2/2.0' }
       });
     }
@@ -341,7 +349,7 @@ export async function getPostDetails(postId: string, site: string): Promise<Post
       } else if (siteConfig.type === 'dodi') {
         response = await fetchDodi(postUrl);
       } else {
-        response = await fetch(postUrl, {
+        response = await siteFetch(postUrl, {
           headers: { 'User-Agent': 'Game-Search-API-v2/2.0' }
         });
       }

--- a/src/lib/gameapi/net.ts
+++ b/src/lib/gameapi/net.ts
@@ -1,0 +1,75 @@
+/**
+ * Network / fetch configuration for game source scraping.
+ *
+ * The Node.js built-in `fetch` is powered by undici, and undici's default
+ * TCP connect timeout is 10s. When any of the piracy/release sites we scrape
+ * is slow to accept a connection (common for Cloudflare-fronted hosts like
+ * skidrowreloaded.com, steamrip.com, dodi-repacks.download, online-fix.me,
+ * freegogpcgames.com) we hit `UND_ERR_CONNECT_TIMEOUT` at 10_000ms no matter
+ * what AbortSignal or per-request timeout we pass. Response timeouts cannot
+ * override the connect timeout — only the dispatcher's `connectTimeout` can.
+ *
+ * To fix the symptom where searches silently fall back to "No results" after
+ * only 10s, we install a global undici dispatcher with a 60s (configurable)
+ * connect timeout. This applies to every `fetch()` call in the server-side
+ * code paths that don't already pass an explicit `dispatcher`.
+ *
+ * Env overrides:
+ *   SITE_CONNECT_TIMEOUT_MS  — TCP connect timeout (default 60_000)
+ *   SITE_HEADERS_TIMEOUT_MS  — time to wait for response headers (default 60_000)
+ *   SITE_BODY_TIMEOUT_MS     — time to wait for response body (default 60_000)
+ *   SITE_KEEPALIVE_TIMEOUT_MS — idle keepalive cap (default 30_000)
+ *
+ * Uses a side-effecting module so the dispatcher is installed exactly once on
+ * first import.
+ */
+
+import { Agent, setGlobalDispatcher } from 'undici';
+
+declare global {
+  // Track whether we've already installed the dispatcher in this process.
+  // Next.js dev mode can evaluate server modules multiple times.
+  var __siteFetchDispatcherInstalled: boolean | undefined;
+}
+
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const n = parseInt(value, 10);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+export const SITE_CONNECT_TIMEOUT_MS = parsePositiveInt(process.env.SITE_CONNECT_TIMEOUT_MS, 60_000);
+export const SITE_HEADERS_TIMEOUT_MS = parsePositiveInt(process.env.SITE_HEADERS_TIMEOUT_MS, 60_000);
+export const SITE_BODY_TIMEOUT_MS = parsePositiveInt(process.env.SITE_BODY_TIMEOUT_MS, 60_000);
+export const SITE_KEEPALIVE_TIMEOUT_MS = parsePositiveInt(process.env.SITE_KEEPALIVE_TIMEOUT_MS, 30_000);
+
+function installDispatcher(): void {
+  if (globalThis.__siteFetchDispatcherInstalled) return;
+
+  const agent = new Agent({
+    connect: {
+      timeout: SITE_CONNECT_TIMEOUT_MS,
+    },
+    headersTimeout: SITE_HEADERS_TIMEOUT_MS,
+    bodyTimeout: SITE_BODY_TIMEOUT_MS,
+    keepAliveTimeout: SITE_KEEPALIVE_TIMEOUT_MS,
+  });
+
+  setGlobalDispatcher(agent);
+  globalThis.__siteFetchDispatcherInstalled = true;
+
+  console.log(
+    `[net] undici global dispatcher installed: connectTimeout=${SITE_CONNECT_TIMEOUT_MS}ms, ` +
+    `headersTimeout=${SITE_HEADERS_TIMEOUT_MS}ms, bodyTimeout=${SITE_BODY_TIMEOUT_MS}ms`
+  );
+}
+
+installDispatcher();
+
+/**
+ * Ensures the dispatcher is installed. Call this from any module that issues
+ * outbound fetches to the external game sites. Safe to call many times.
+ */
+export function ensureSiteFetchDispatcher(): void {
+  installDispatcher();
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Searching keeps failing: clicking Search silently falls back to the recent-uploads list, and even a few minutes later the search returns no results. The server logs are full of:

```
ConnectTimeoutError: Connect Timeout Error (attempted address: steamrip.com:443, timeout: 10000ms)
ConnectTimeoutError: Connect Timeout Error (attempted address: www.skidrowreloaded.com:443, timeout: 10000ms)
ConnectTimeoutError: Connect Timeout Error (attempted address: dodi-repacks.download:443, timeout: 10000ms)
…
Skidrow circuit opened for 300s after failure #1: fetch failed
DODI circuit opened for 300s after failure #1: fetch failed
```

## Root cause

Three compounding issues in `src/lib/gameapi/`:

1. **Node's built-in `fetch` is undici, and undici's default TCP `connectTimeout` is 10s.** No `AbortSignal`, `fetchWithTimeout` wrapper, or per-request timeout can raise it — only a custom `undici.Agent` can. Every single site scrape was silently capped at 10s on the TCP connect, which is where the `timeout: 10000ms` in the error log came from.
2. **The raw `fetch()` calls in `helpers.js` / `index.ts` had no end-to-end timeout at all.** Once undici's 10s connect cap was bypassed (or after we raise it), there was no next-layer ceiling, so a hung response would block a whole search.
3. **The Skidrow/DODI circuit breakers open for 300s after a single failure.** Combined with the above, one flaky 10s TCP connect tripped the breaker, and the next few searches "a few minutes later" still returned nothing from those sites even if the network recovered.

## Fix

- New `src/lib/gameapi/net.ts` installs a **global undici dispatcher** (`Agent`) with a 60s TCP `connectTimeout`, `headersTimeout`, and `bodyTimeout`, and is imported as a side effect from `src/lib/gameapi/index.ts` so it's wired in before any gameapi code runs.
- New `siteFetch(resource, opts, timeoutMs=60_000)` wrapper in `helpers.js` enforces a hard end-to-end request timeout via `AbortSignal.timeout` (composed with any caller-supplied `signal` via `AbortSignal.any`).
- All direct `fetch()` calls to external sources now go through `siteFetch`: `fetchSteamrip`, `fetchSkidrow`, `fetchDodi`, `fetchOnlineFixRecent`, `fetchOnlineFixSearch`, `fetchGogGamesRecent`, the post-detail link extractor, and the WP-REST callers in `index.ts`.
- Bump `DEFAULT_FLARE_TIMEOUT_MS` from 30s to 60s and remove the `Math.min(25000, …)` clamps in `getFreshSkidrowCookie`, `getFreshDodiCookie`, and `fetchViaFlaresolverr`. FlareSolverr renders a browser to solve CF challenges; 25s was too tight for cold solves.
- Soften the Skidrow and DODI circuit breakers:
  - Require 2 consecutive failures before opening (was 1), configurable via `SKIDROW_FAILURE_THRESHOLD` / `DODI_FAILURE_THRESHOLD`.
  - Default cooldown 60s (was 300s).
- Document all new knobs in `.env.example`:
  - `SITE_FETCH_TIMEOUT_MS`, `SITE_CONNECT_TIMEOUT_MS`, `SITE_HEADERS_TIMEOUT_MS`, `SITE_BODY_TIMEOUT_MS`
  - `FLARE_TIMEOUT_MS`, `FLARE_RETRIES`
  - `SKIDROW_COOLDOWN_MS`, `SKIDROW_FAILURE_THRESHOLD`, `DODI_COOLDOWN_MS`, `DODI_FAILURE_THRESHOLD`

## Dependency change

Adds `undici@^7.25.0` as a direct dependency. Node ships undici internally, but importing it as a package is the only way to configure `Agent`/`setGlobalDispatcher` without monkey-patching `node:internal/*`.

## Verification

- `npx tsc --noEmit` clean.
- `npm run lint` clean for all changed files (`src/lib/gameapi/net.ts`, `helpers.js`, `index.ts`).
- `npx next build --turbopack` succeeds.
- Manual smoke test of the `siteFetch` timeout composition against `httpbin.org/delay/*`: 2s timeout against a 10s endpoint aborts with `TimeoutError` at ~2s as expected.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0855bb2e-be36-47c1-8855-619e7d9ee159"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0855bb2e-be36-47c1-8855-619e7d9ee159"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

