### PR TITLE
fix(dashboard): cancel recent-uploads poll before running a search

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -90,6 +90,21 @@ function DashboardInner() {
     return fetchAbortRef.current.signal;
   }, []);
 
+  // Stop any in-flight recent-uploads enrichment poll. The poll is kicked off
+  // by `loadRecentGames` and calls `setGames(pollData)` every 2s; without
+  // this, starting a search immediately after mount would have the next poll
+  // tick overwrite the search results with fresh recent uploads — which is
+  // exactly the "search results flash then jump back to recent uploads"
+  // behaviour we're guarding against here. Also clears `enriching` because
+  // the spinner is no longer meaningful once the user has moved on.
+  const cancelRecentPoll = useCallback(() => {
+    if (pollIntervalRef.current) {
+      clearInterval(pollIntervalRef.current);
+      pollIntervalRef.current = null;
+    }
+    setEnriching(false);
+  }, []);
+
   useEffect(() => {
     if (!fetchAbortRef.current) fetchAbortRef.current = new AbortController();
     return () => {
@@ -190,6 +205,7 @@ function DashboardInner() {
       const timer = setTimeout(() => {
         const performInitialSearch = async () => {
           const signal = getFetchSignal();
+          cancelRecentPoll();
           setLoading(true);
           setError(null);
           try {
@@ -222,7 +238,7 @@ function DashboardInner() {
 
       return () => clearTimeout(timer);
     }
-  }, [searchParams, getFetchSignal]);
+  }, [searchParams, getFetchSignal, cancelRecentPoll]);
 
   // Function to set cookie with 1 hour expiration
   const setRecentGamesCookie = (show: boolean) => {
@@ -372,6 +388,7 @@ function DashboardInner() {
     updateURL(searchQuery, siteFilter, refineText);
 
     const signal = getFetchSignal();
+    cancelRecentPoll();
     setLoading(true);
     setError(null);
     try {
@@ -398,7 +415,7 @@ function DashboardInner() {
     } finally {
       if (!signal.aborted) setLoading(false);
     }
-  }, [searchQuery, siteFilter, refineText, loadRecentGames, updateURL, getFetchSignal]);
+  }, [searchQuery, siteFilter, refineText, loadRecentGames, updateURL, getFetchSignal, cancelRecentPoll]);
 
   // Load recent games on mount and check cookie/user preference for visibility
   useEffect(() => {
@@ -710,6 +727,7 @@ function DashboardInner() {
                         if (site.value !== 'all') params.set('site', site.value);
                         if (refineText.trim()) params.set('refine', refineText);
                         updateURL(searchQuery, site.value, refineText);
+                        cancelRecentPoll();
                         setLoading(true);
                         setError(null);
                         const signal = getFetchSignal();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After [#9](https://github.com/darkmaster420/AIOgames/pull/9) fixed the connect-timeout failures, searches complete successfully — but the results flash on screen for a second or two and then the page jumps back to the recent-uploads grid, as if the search never happened.

## Root cause

`loadRecentGames` in `src/app/page.tsx` kicks off a 2-second `setInterval` that polls `/api/games/recent` for background image / Steam AppID enrichment. Every tick calls:

```ts
setGames(pollData);
```

When the user submits a search while this poll is still alive (which is always, on the initial page view — the poll was just started on mount), the next poll tick lands ~2s later and **overwrites `games` with the fresh recent-uploads response**. The search results are still in `games` at that moment, so they disappear and the UI reverts to the recent grid.

`loadRecentGames` already clears its own prior poll before starting a new one, but none of the search entrypoints did. That's the race.

## Fix

Introduce `cancelRecentPoll()` in `DashboardInner`:

```tsx
const cancelRecentPoll = useCallback(() => {
  if (pollIntervalRef.current) {
    clearInterval(pollIntervalRef.current);
    pollIntervalRef.current = null;
  }
  setEnriching(false);
}, []);
```

and call it at the top of every search entrypoint:

- the URL-sync initial-search `useEffect` (e.g. navigating directly to `/?search=foo`)
- the main `searchGames` form handler
- the site-filter chip that auto-reruns a search when the user picks a specific site

`loadRecentGames` is unchanged — it already cancels its previous poll before starting a new one.

## Verification

- `npx tsc --noEmit` clean.
- `npx eslint src/app/page.tsx` clean for all changed lines (only a pre-existing `enrichTimeoutRef.current` warning from before this PR remains).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0855bb2e-be36-47c1-8855-619e7d9ee159"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0855bb2e-be36-47c1-8855-619e7d9ee159"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

