### PR TITLE
fix(dashboard): cancel enrichment poll when clicking a site filter on recent uploads

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -720,6 +720,14 @@ function DashboardInner() {
                     key={site.value}
                     onClick={() => {
                       setSiteFilter(site.value);
+                      // Always cancel the background enrichment poll before
+                      // kicking off a filter fetch. Otherwise the next poll
+                      // tick (every 2s) calls `/api/games/recent` with *no*
+                      // site param and overwrites the site-filtered games
+                      // with the unfiltered recent grid — which is what made
+                      // filter clicks appear to "bounce back" to recent
+                      // uploads.
+                      cancelRecentPoll();
                       // Auto-apply: trigger filter immediately
                       // Use site.value directly (not stale siteFilter from closure)
                       if (searchQuery.trim()) {
@@ -727,7 +735,6 @@ function DashboardInner() {
                         if (site.value !== 'all') params.set('site', site.value);
                         if (refineText.trim()) params.set('refine', refineText);
                         updateURL(searchQuery, site.value, refineText);
-                        cancelRecentPoll();
                         setLoading(true);
                         setError(null);
                         const signal = getFetchSignal();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Even after [#10](https://github.com/darkmaster420/AIOgames/pull/10), clicking any site-filter chip from the recent-uploads view makes the page flash the filtered results for a couple of seconds and then snap back to the unfiltered recent uploads.

## Root cause

On mount, `loadRecentGames` fires a background enrichment poll — a 2-second `setInterval` that hits `/api/games/recent` (with **no** site param) and calls `setGames(pollData)` every tick. PR #10 cancelled this poll before running a search, but the site-filter chip's inline onClick only cancelled it on the `searchQuery.trim()` branch. When the user was on the plain recent-uploads view and clicked a filter chip:

1. onClick calls `fetch('/api/games/recent?site=steamrip')`, swaps the filtered games into `games`.
2. ~2 seconds later the still-alive enrichment poll ticks, fetches `/api/games/recent` (unfiltered), and overwrites `games` with the full unfiltered list.

That's the "bounce back" the user is seeing.

## Fix

Move the existing `cancelRecentPoll()` call from inside the `searchQuery.trim()` branch up to the top of the onClick, so it runs unconditionally — covering both the search-active-filter path and the recent-uploads-filter path.

```diff
 onClick={() => {
   setSiteFilter(site.value);
+  cancelRecentPoll();
   if (searchQuery.trim()) {
-    ...
-    cancelRecentPoll();
```

No other behaviour change. `loadRecentGames` and the main `searchGames` handler already cancel the poll themselves.

## Verification

- `npx tsc --noEmit` clean.
- `npx eslint src/app/page.tsx` clean on changed lines (only the pre-existing `enrichTimeoutRef.current` warning from before this series remains).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0855bb2e-be36-47c1-8855-619e7d9ee159"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0855bb2e-be36-47c1-8855-619e7d9ee159"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

