### PR TITLE
feat(recent): retry unverified titles on every refresh via short-TTL cooldowns

### DIFF
--- a/src/app/api/games/recent/route.ts
+++ b/src/app/api/games/recent/route.ts
@@ -1,8 +1,12 @@
 import { NextResponse, NextRequest } from 'next/server';
 import { cleanGameTitle } from '../../../../utils/steamApi';
-import { resolveIGDBImage } from '../../../../utils/igdb';
+import { resolveIGDBImage, clearNegativeImageCache } from '../../../../utils/igdb';
 import { getRecentUploads } from '../../../../lib/gameapi';
-import { peekCachedSteamAppId, resolveSteamAppIdsBatch } from '../../../../utils/steamAppIdResolver';
+import {
+  peekCachedSteamAppId,
+  resolveSteamAppIdsBatch,
+  clearNegativeAppIdCache,
+} from '../../../../utils/steamAppIdResolver';
 import { prefetchImageBatch, getCachedImage } from '../../../../utils/imageCache';
 
 // Allow up to 2 minutes for initial data fetch (scraping multiple sites via FlareSolverr)
@@ -12,17 +16,45 @@ export const maxDuration = 120;
 let cachedRecent: { results: Game[]; timestamp: number; siteKey: string } | null = null;
 const CACHE_TTL_MS = 2 * 60 * 60 * 1000; // 2 hours
 
-// Track titles that failed both IGDB and RAWG — don't retry until cache expires
-const failedImageTitles = new Set<string>();
+// Titles we've tried to enrich and failed. The value is the Unix-ms timestamp
+// after which we're allowed to retry the title again. Using a timestamped
+// map (instead of a permanent Set) means a transient IGDB/Steam blip no
+// longer locks a title out of enrichment until the whole recent-uploads
+// cache expires — each refresh naturally retries anything whose cooldown
+// has elapsed.
+const failedImageTitles = new Map<string, number>();
+const failedAppIdTitles = new Map<string, number>();
+
+// Cooldowns for re-attempting a title after a failed enrichment. These are
+// intentionally short so the user sees more cards verify on subsequent page
+// refreshes even without clicking the hard-refresh button. The Steam resolver
+// and IGDB helper also keep their own negative caches — these values are
+// loosely aligned with them so we don't stampede the upstream APIs.
+const IMAGE_RETRY_AFTER_MS = 10 * 60 * 1000; // 10m — aligned with IMAGE_MISS_TTL in utils/igdb.ts
+const APPID_RETRY_AFTER_MS = 2 * 60 * 1000;  // 2m — short enough that a few refreshes will pick up
+                                             //      anything whose resolver cache has expired.
 
 // Track whether background enrichment is already running
 let enrichmentRunning = false;
 let appIdEnrichmentRunning = false;
 let imagePrefetchRunning = false;
 
-// Titles we've already tried to resolve and failed — don't re-hit Steam for
-// them until the fresh-scrape cache expires.
-const failedAppIdTitles = new Set<string>();
+function shouldRetryTitle(map: Map<string, number>, key: string): boolean {
+  const until = map.get(key);
+  if (!until) return true;
+  if (Date.now() >= until) {
+    map.delete(key);
+    return true;
+  }
+  return false;
+}
+
+function pruneFailedTitleMap(map: Map<string, number>): void {
+  const now = Date.now();
+  for (const [key, until] of map) {
+    if (now >= until) map.delete(key);
+  }
+}
 
 interface Game {
   siteType: string;
@@ -46,10 +78,13 @@ function hasNativeAppId(game: Game): boolean {
 function enrichInBackground() {
   if (enrichmentRunning || !cachedRecent) return;
 
+  pruneFailedTitleMap(failedImageTitles);
+
   const gamesNeedingImages = cachedRecent.results.filter((g: Game) => {
     if (g.image) return false;
     const searchTitle = (g.title as string).trim();
-    return searchTitle && !failedImageTitles.has(searchTitle.toLowerCase());
+    if (!searchTitle) return false;
+    return shouldRetryTitle(failedImageTitles, searchTitle.toLowerCase());
   });
 
   if (gamesNeedingImages.length === 0) return;
@@ -69,7 +104,12 @@ function enrichInBackground() {
         if (image) {
           imageMap.set(searchTitle, image);
         } else {
-          failedImageTitles.add(searchTitle.toLowerCase());
+          // Short cooldown: the next enrichment pass (triggered by a user
+          // refresh or the site-level 2-hour expiry) will retry.
+          failedImageTitles.set(
+            searchTitle.toLowerCase(),
+            Date.now() + IMAGE_RETRY_AFTER_MS
+          );
         }
         // 300ms delay between requests to stay under IGDB rate limit
         await new Promise(r => setTimeout(r, 300));
@@ -139,11 +179,13 @@ function prefetchImageBytesInBackground() {
 function enrichAppIdsInBackground() {
   if (appIdEnrichmentRunning || !cachedRecent) return;
 
+  pruneFailedTitleMap(failedAppIdTitles);
+
   const gamesNeedingAppId = cachedRecent.results.filter((g: Game) => {
     if (hasNativeAppId(g)) return false;
     const cleanTitle = cleanGameTitle(g.originalTitle || g.title || '').trim();
     if (!cleanTitle) return false;
-    return !failedAppIdTitles.has(cleanTitle.toLowerCase());
+    return shouldRetryTitle(failedAppIdTitles, cleanTitle.toLowerCase());
   });
 
   if (gamesNeedingAppId.length === 0) return;
@@ -167,7 +209,12 @@ function enrichAppIdsInBackground() {
             return { ...game, appid: appId } as Game;
           }
           const cleanTitle = cleanGameTitle(rawTitle).trim();
-          if (cleanTitle) failedAppIdTitles.add(cleanTitle.toLowerCase());
+          if (cleanTitle) {
+            failedAppIdTitles.set(
+              cleanTitle.toLowerCase(),
+              Date.now() + APPID_RETRY_AFTER_MS
+            );
+          }
           return game;
         });
       }
@@ -185,11 +232,28 @@ export async function GET(request: NextRequest) {
     const { searchParams } = new URL(request.url);
     const site = searchParams.get('site') || 'all';
     const forceRefresh = searchParams.get('refresh') === 'true';
+    // Client can ask for a full re-verification pass without re-scraping the
+    // source sites. This clears the per-title failure cooldowns so every
+    // unverified game gets another IGDB/Steam attempt on this request's
+    // background enrichment cycle. Useful for the user-facing Refresh button
+    // or a manual `/api/games/recent?reverify=true` call.
+    const forceReverify = searchParams.get('reverify') === 'true';
 
     const now = Date.now();
     const cacheKey = 'all';
     let results: Game[];
     let isFromCache = false;
+
+    if (forceReverify) {
+      failedImageTitles.clear();
+      failedAppIdTitles.clear();
+      const clearedAppIds = clearNegativeAppIdCache();
+      const clearedImages = clearNegativeImageCache();
+      console.log(
+        `[Recent] Reverify requested — cleared cooldowns ` +
+        `(resolver negatives: ${clearedAppIds}, image negatives: ${clearedImages})`
+      );
+    }
 
     if (!forceRefresh && cachedRecent && (now - cachedRecent.timestamp) < CACHE_TTL_MS && cachedRecent.siteKey === cacheKey) {
       results = cachedRecent.results;

--- a/src/utils/igdb.ts
+++ b/src/utils/igdb.ts
@@ -231,10 +231,14 @@ export async function getIGDBGameDetails(igdbId: number): Promise<IGDBSearchResu
   }
 }
 
-// Lightweight image-only cache: title → cover URL
-const gameImageCache = new Map<string, { url: string; timestamp: number }>();
+// Lightweight image-only cache: title → cover URL (or null if we've tried
+// recently and got nothing). Entries with a `url` live for the source's long
+// TTL; null entries live for a short TTL so a transient IGDB/RAWG failure
+// doesn't lock the title out until the whole recent-uploads cache expires.
+const gameImageCache = new Map<string, { url: string | null; timestamp: number }>();
 const IGDB_CACHE_TTL = 24 * 60 * 60 * 1000; // 24 hours for IGDB results
 const RAWG_CACHE_TTL = 7 * 24 * 60 * 60 * 1000; // 1 week for RAWG results (20k req/month limit)
+const IMAGE_MISS_TTL = 10 * 60 * 1000; // 10 minutes for null entries — retry periodically
 
 const RAWG_API_KEY = process.env.RAWG_API_KEY;
 
@@ -274,17 +278,38 @@ async function resolveRAWGImage(title: string): Promise<string | null> {
 }
 
 /**
- * Resolve a game image — tries IGDB first, then RAWG as fallback.
- * Only successful results are cached. Failures retry every request.
+ * Forget every cached image miss (null entries). Successful image hits stay
+ * in cache. Used by the /api/games/recent reverify path to force another
+ * IGDB/RAWG attempt for titles whose previous lookups returned nothing.
+ */
+export function clearNegativeImageCache(): number {
+  let removed = 0;
+  for (const [key, entry] of gameImageCache) {
+    if (!entry.url) {
+      gameImageCache.delete(key);
+      removed++;
+    }
+  }
+  return removed;
+}
+
+/**
+ * Resolve a game image — tries IGDB first, then RAWG as fallback. Successful
+ * lookups are cached for the provider's long TTL; misses are cached briefly
+ * (IMAGE_MISS_TTL) so we don't retry every second but still give titles a
+ * chance to resolve when the next enrichment pass runs a few minutes later.
  */
 export async function resolveIGDBImage(title: string): Promise<string | null> {
   const cacheKey = title.toLowerCase().trim();
   if (!cacheKey) return null;
 
-  // Check cache (uses the longer TTL of the two sources)
   const cached = gameImageCache.get(cacheKey);
   if (cached) {
-    const ttl = cached.url.includes('rawg.io') ? RAWG_CACHE_TTL : IGDB_CACHE_TTL;
+    const ttl = !cached.url
+      ? IMAGE_MISS_TTL
+      : cached.url.includes('rawg.io')
+        ? RAWG_CACHE_TTL
+        : IGDB_CACHE_TTL;
     if ((Date.now() - cached.timestamp) < ttl) {
       return cached.url;
     }
@@ -349,5 +374,9 @@ export async function resolveIGDBImage(title: string): Promise<string | null> {
     return rawgImage;
   }
 
+  // Remember the miss briefly so we don't stampede the same APIs on every
+  // refresh; the next enrichment pass will re-attempt once IMAGE_MISS_TTL
+  // elapses.
+  gameImageCache.set(cacheKey, { url: null, timestamp: Date.now() });
   return null;
 }

--- a/src/utils/steamAppIdResolver.ts
+++ b/src/utils/steamAppIdResolver.ts
@@ -22,65 +22,93 @@ interface SteamSearchHit {
 interface CacheEntry {
   appId: string | null;
   timestamp: number;
+  // `true` when the miss was caused by a network / timeout / parse error, so
+  // we can expire it aggressively and retry on the next enrichment pass.
+  transient?: boolean;
 }
 
 const resolverCache = new Map<string, CacheEntry>();
 // Successful resolutions are effectively permanent (7 days). Negative lookups
 // get a much shorter TTL so new Steam listings can be picked up relatively
-// quickly.
+// quickly — and we shorten it further for network/transient failures so a
+// single blip doesn't lock out a title for the whole hour.
 const POSITIVE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
-const NEGATIVE_TTL_MS = 60 * 60 * 1000;
+const NEGATIVE_TTL_MS = 15 * 60 * 1000; // 15m: genuine "not found" on Steam
+const TRANSIENT_FAIL_TTL_MS = 60 * 1000; // 1m: Steam request errored out
 
 const SIMILARITY_THRESHOLD = 0.45;
 const MAX_CANDIDATES = 8;
 const STEAM_SEARCH_URL = 'https://steamcommunity.com/actions/SearchApps/';
-const STEAM_SEARCH_TIMEOUT_MS = 5000;
+const STEAM_SEARCH_TIMEOUT_MS = 8000;
 
 // Dedupe in-flight requests for the same title so concurrent resolve() calls
 // don't each hit Steam's endpoint.
 const inflight = new Map<string, Promise<string | null>>();
 
+function ttlForEntry(entry: CacheEntry): number {
+  if (entry.appId) return POSITIVE_TTL_MS;
+  return entry.transient ? TRANSIENT_FAIL_TTL_MS : NEGATIVE_TTL_MS;
+}
+
 function getCached(key: string): CacheEntry | null {
   const entry = resolverCache.get(key);
   if (!entry) return null;
-  const ttl = entry.appId ? POSITIVE_TTL_MS : NEGATIVE_TTL_MS;
-  if (Date.now() - entry.timestamp > ttl) {
+  if (Date.now() - entry.timestamp > ttlForEntry(entry)) {
     resolverCache.delete(key);
     return null;
   }
   return entry;
 }
 
-async function searchSteamCommunity(query: string): Promise<SteamSearchHit[]> {
+interface SearchResult {
+  hits: SteamSearchHit[];
+  /** `true` if Steam returned a successful (even empty) response. `false` if
+   *  the request errored out — we use this to flag cache entries as
+   *  transient so they get retried promptly instead of sitting in the
+   *  15-minute negative cache. */
+  ok: boolean;
+}
+
+async function searchSteamCommunity(query: string): Promise<SearchResult> {
   try {
     const response = await fetch(`${STEAM_SEARCH_URL}${encodeURIComponent(query)}`, {
       signal: AbortSignal.timeout(STEAM_SEARCH_TIMEOUT_MS),
       headers: { 'User-Agent': 'AIOGames-AppIdResolver/1.0' },
     });
-    if (!response.ok) return [];
+    if (!response.ok) return { hits: [], ok: false };
     const data = await response.json();
-    if (!Array.isArray(data)) return [];
-    return data
+    if (!Array.isArray(data)) return { hits: [], ok: false };
+    const hits = data
       .slice(0, 20)
       .map((item: { appid: string | number; name: string }) => ({
         appid: String(item.appid),
         name: item.name || '',
       }))
-      .filter(hit => hit.appid && hit.name);
+      .filter((hit: SteamSearchHit) => hit.appid && hit.name);
+    return { hits, ok: true };
   } catch {
-    return [];
+    return { hits: [], ok: false };
   }
 }
 
-async function doResolve(cleanTitle: string): Promise<string | null> {
-  if (!cleanTitle || cleanTitle.length < 2) return null;
+interface DoResolveResult {
+  appId: string | null;
+  transient: boolean;
+}
+
+async function doResolve(cleanTitle: string): Promise<DoResolveResult> {
+  if (!cleanTitle || cleanTitle.length < 2) {
+    return { appId: null, transient: false };
+  }
 
   const variants = buildSteamSearchQueryVariants(cleanTitle);
   const seen = new Set<string>();
   const candidates: SteamSearchHit[] = [];
+  let anyOk = false;
 
   for (const variant of variants) {
-    const hits = await searchSteamCommunity(variant);
+    const { hits, ok } = await searchSteamCommunity(variant);
+    if (ok) anyOk = true;
     for (const hit of hits) {
       if (seen.has(hit.appid)) continue;
       seen.add(hit.appid);
@@ -90,7 +118,13 @@ async function doResolve(cleanTitle: string): Promise<string | null> {
     if (candidates.length >= MAX_CANDIDATES) break;
   }
 
-  if (candidates.length === 0) return null;
+  // If every variant request errored, treat the whole lookup as transient —
+  // a future refresh should retry within a minute instead of waiting 15.
+  if (!anyOk && candidates.length === 0) {
+    return { appId: null, transient: true };
+  }
+
+  if (candidates.length === 0) return { appId: null, transient: false };
 
   let best: { appid: string; score: number } | null = null;
   for (const hit of candidates.slice(0, MAX_CANDIDATES)) {
@@ -103,9 +137,9 @@ async function doResolve(cleanTitle: string): Promise<string | null> {
   }
 
   if (best && best.score >= SIMILARITY_THRESHOLD) {
-    return best.appid;
+    return { appId: best.appid, transient: false };
   }
-  return null;
+  return { appId: null, transient: false };
 }
 
 /**
@@ -137,13 +171,14 @@ export async function resolveSteamAppId(rawTitle: string): Promise<string | null
 
   const promise = (async () => {
     try {
-      const appId = await doResolve(cleanTitle);
-      resolverCache.set(key, { appId, timestamp: Date.now() });
+      const { appId, transient } = await doResolve(cleanTitle);
+      resolverCache.set(key, { appId, timestamp: Date.now(), transient });
       return appId;
     } catch (err) {
       console.warn(`[steamAppIdResolver] Failed to resolve "${cleanTitle}":`, err);
-      // Cache the negative briefly to avoid hammering on transient errors.
-      resolverCache.set(key, { appId: null, timestamp: Date.now() });
+      // Cache the negative as transient so the next enrichment pass retries
+      // within a minute instead of waiting 15.
+      resolverCache.set(key, { appId: null, timestamp: Date.now(), transient: true });
       return null;
     } finally {
       inflight.delete(key);
@@ -152,6 +187,25 @@ export async function resolveSteamAppId(rawTitle: string): Promise<string | null
 
   inflight.set(key, promise);
   return promise;
+}
+
+/**
+ * Forget every cached negative result (both transient and genuine misses).
+ * Positive hits are left alone — they are effectively permanent.
+ *
+ * Used by the /api/games/recent reverify path to force a re-query of Steam
+ * for all titles the previous pass couldn't resolve, without invalidating
+ * the good matches we've already found.
+ */
+export function clearNegativeAppIdCache(): number {
+  let removed = 0;
+  for (const [key, entry] of resolverCache) {
+    if (!entry.appId) {
+      resolverCache.delete(key);
+      removed++;
+    }
+  }
+  return removed;
 }
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

A lot of posts stay stuck as "unverified" across many page refreshes, even though a retry would usually resolve them. Once a title missed once, it was treated as permanently unverifiable until the whole 2-hour recent-uploads cache expired.

## Root cause

`src/app/api/games/recent/route.ts` tracked enrichment failures in two permanent `Set`s:

```ts
const failedImageTitles = new Set<string>();
const failedAppIdTitles = new Set<string>();
```

Every request filtered those titles out of background enrichment. A single transient blip (`steamcommunity.com` timing out, IGDB rate-limiting, etc.) was enough to bury the title for up to two hours.

Two helper caches compounded the issue:

- `src/utils/steamAppIdResolver.ts` cached **every** null result for 60 minutes with a single `NEGATIVE_TTL_MS`, treating a network timeout identically to a genuine "no Steam listing exists" miss.
- `src/utils/igdb.ts` only cached successful image lookups — misses hit IGDB and RAWG on every call, stampeding those APIs on each poll tick while never giving them a chance to resolve in the background later.

## Fix

### Route (`src/app/api/games/recent/route.ts`)

- Replace the permanent `Set`s with `Map<titleKey, retryAfterEpochMs>`. A failed title is merely on cooldown, not banned.
- Cooldowns: **10 min** for images, **2 min** for Steam AppIDs (loosely aligned with the helper-cache TTLs below).
- `shouldRetryTitle` / `pruneFailedTitleMap` take care of promoting titles back into the enrichment candidate list once their cooldown elapses, so every subsequent `/api/games/recent` response triggers enrichment for anything past its cooldown.
- New query param: `GET /api/games/recent?reverify=true`. Clears *only negative* entries across all three caches (route, resolver, image) to force another IGDB/Steam attempt for every unverified title without re-scraping the source sites. Positive matches are preserved.

### Resolver (`src/utils/steamAppIdResolver.ts`)

- Distinguish a **transient** failure (network error, timeout, non-2xx from `steamcommunity.com`) from a **genuine** miss (Steam returned `[]`). Transient failures cache for **60 s** (down from 60 min); genuine misses cache for **15 min**.
- `doResolve` now also reports `transient: true` when every search variant errored out.
- Bumped `STEAM_SEARCH_TIMEOUT_MS` from 5 s → 8 s. The global undici dispatcher (installed in #9) now allows longer TCP connects, so 5 s was often too tight for `steamcommunity.com`.
- New `clearNegativeAppIdCache()` helper (wired into the `reverify=true` path).

### Image helper (`src/utils/igdb.ts`)

- Cache image **misses** for **10 min** (was "never cached"). Prevents IGDB/RAWG stampedes on each poll tick and gives titles a chance to resolve in background passes.
- New `clearNegativeImageCache()` helper (wired into the `reverify=true` path).

## Net user-visible effect

- Simply reloading the page ~2 minutes after the initial load now re-attempts Steam AppID verification for any title whose previous lookup failed, without the user having to click the full-scrape **🔄 Refresh** button.
- Images get the same treatment on a 10-minute cadence.
- For power users: `GET /api/games/recent?reverify=true` forces an immediate reverify pass across the entire cached grid.

## Verification

- `npx tsc --noEmit` clean.
- `npx eslint` clean on all changed files.
- `npx next build --turbopack` succeeds.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0855bb2e-be36-47c1-8855-619e7d9ee159"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0855bb2e-be36-47c1-8855-619e7d9ee159"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

