### PR TITLE
feat(recent): per-site auto-recovery (empty-site refresh + verified:unverified ratio reverify + per-site refresh endpoint)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,35 @@ FLARESOLVERR_URL=http://flaresolverr:8191/v1
 # SKIDROW_FAILURE_THRESHOLD=2
 # DODI_FAILURE_THRESHOLD=2
 
+# 🔁 Recent-uploads auto-recovery (per-site verified/unverified ratios)
+# The /api/games/recent route tracks per-site stats and auto-triggers two
+# kinds of background recovery when the cached grid looks unhealthy:
+#
+#   1. Empty-site refresh — any site with 0 posts in the cache is
+#      re-scraped alone (no bulk re-scrape) via the per-site endpoint.
+#   2. Ratio-based reverify — if any site has at least
+#      RECENT_UNVERIFIED_TRIGGER unverified posts AND its
+#      verified:unverified ratio is below RECENT_VERIFIED_RATIO, all
+#      per-title negative caches are cleared and enrichment re-runs.
+#
+# Both actions are rate-limited by their respective cooldowns.
+#
+# Minimum unverified-post count on a single site that can trigger a
+# reverify. Defaults to 10. Lower = more eager, higher = calmer.
+# RECENT_UNVERIFIED_TRIGGER=10
+# Minimum acceptable verified:unverified ratio for a site. Defaults to 2
+# (i.e. at least twice as many verified as unverified posts). Match the
+# ideal 20:1 by setting this to 20 — but any site with 10+ unverified and
+# a ratio below this value is considered overloaded.
+# RECENT_VERIFIED_RATIO=2
+# Minimum milliseconds between per-site background refreshes. Defaults
+# to 300000 (5m). The on-demand endpoint can bypass this with ?force=true.
+# RECENT_SITE_REFRESH_COOLDOWN_MS=300000
+# Minimum milliseconds between auto-reverify passes. Defaults to 300000
+# (5m). The manual ?reverify=true query param on /api/games/recent
+# bypasses this cooldown.
+# RECENT_REVERIFY_COOLDOWN_MS=300000
+
 # 📦 Environment use development .env if youre developing!!
 NODE_ENV=production
 

--- a/src/app/api/games/recent/route.ts
+++ b/src/app/api/games/recent/route.ts
@@ -1,230 +1,30 @@
 import { NextResponse, NextRequest } from 'next/server';
-import { cleanGameTitle } from '../../../../utils/steamApi';
-import { resolveIGDBImage, clearNegativeImageCache } from '../../../../utils/igdb';
-import { getRecentUploads } from '../../../../lib/gameapi';
 import {
-  peekCachedSteamAppId,
-  resolveSteamAppIdsBatch,
-  clearNegativeAppIdCache,
-} from '../../../../utils/steamAppIdResolver';
-import { prefetchImageBatch, getCachedImage } from '../../../../utils/imageCache';
+  CACHE_TTL_MS,
+  Game,
+  SiteStat,
+  enrichAppIdsInBackground,
+  enrichInBackground,
+  fetchAndCacheRecent,
+  getCachedRecent,
+  hasNativeAppId,
+  prefetchImageBytesInBackground,
+  runAutoRecovery,
+  triggerReverify,
+} from '../../../../lib/recentUploadsState';
 
 // Allow up to 2 minutes for initial data fetch (scraping multiple sites via FlareSolverr)
 export const maxDuration = 120;
 
-// Simple in-memory cache — stores results (progressively enriched with IGDB images)
-let cachedRecent: { results: Game[]; timestamp: number; siteKey: string } | null = null;
-const CACHE_TTL_MS = 2 * 60 * 60 * 1000; // 2 hours
-
-// Titles we've tried to enrich and failed. The value is the Unix-ms timestamp
-// after which we're allowed to retry the title again. Using a timestamped
-// map (instead of a permanent Set) means a transient IGDB/Steam blip no
-// longer locks a title out of enrichment until the whole recent-uploads
-// cache expires — each refresh naturally retries anything whose cooldown
-// has elapsed.
-const failedImageTitles = new Map<string, number>();
-const failedAppIdTitles = new Map<string, number>();
-
-// Cooldowns for re-attempting a title after a failed enrichment. These are
-// intentionally short so the user sees more cards verify on subsequent page
-// refreshes even without clicking the hard-refresh button. The Steam resolver
-// and IGDB helper also keep their own negative caches — these values are
-// loosely aligned with them so we don't stampede the upstream APIs.
-const IMAGE_RETRY_AFTER_MS = 10 * 60 * 1000; // 10m — aligned with IMAGE_MISS_TTL in utils/igdb.ts
-const APPID_RETRY_AFTER_MS = 2 * 60 * 1000;  // 2m — short enough that a few refreshes will pick up
-                                             //      anything whose resolver cache has expired.
-
-// Track whether background enrichment is already running
-let enrichmentRunning = false;
-let appIdEnrichmentRunning = false;
-let imagePrefetchRunning = false;
-
-function shouldRetryTitle(map: Map<string, number>, key: string): boolean {
-  const until = map.get(key);
-  if (!until) return true;
-  if (Date.now() >= until) {
-    map.delete(key);
-    return true;
-  }
-  return false;
-}
-
-function pruneFailedTitleMap(map: Map<string, number>): void {
-  const now = Date.now();
-  for (const [key, until] of map) {
-    if (now >= until) map.delete(key);
-  }
-}
-
-interface Game {
-  siteType: string;
-  id: string;
-  title: string;
-  originalTitle?: string;
-  source: string;
-  appid?: number | string;
-  appId?: number | string;
-  steamAppId?: number | string;
-  steam_appid?: number | string;
-  [key: string]: unknown;
-}
-
-function hasNativeAppId(game: Game): boolean {
-  const candidates = [game.appid, game.appId, game.steamAppId, game.steam_appid];
-  return candidates.some(c => c !== undefined && c !== null && /^\d+$/.test(String(c).trim()));
-}
-
-// Background enrichment — runs after response is sent, updates cache in-place
-function enrichInBackground() {
-  if (enrichmentRunning || !cachedRecent) return;
-
-  pruneFailedTitleMap(failedImageTitles);
-
-  const gamesNeedingImages = cachedRecent.results.filter((g: Game) => {
-    if (g.image) return false;
-    const searchTitle = (g.title as string).trim();
-    if (!searchTitle) return false;
-    return shouldRetryTitle(failedImageTitles, searchTitle.toLowerCase());
-  });
-
-  if (gamesNeedingImages.length === 0) return;
-
-  enrichmentRunning = true;
-  console.log(`[Recent] Background enrichment starting for ${gamesNeedingImages.length} games...`);
-
-  // Fire-and-forget async enrichment
-  (async () => {
-    try {
-      const imageMap = new Map<string, string>();
-      for (const game of gamesNeedingImages) {
-        const searchTitle = (game.title as string).trim();
-        if (!searchTitle || imageMap.has(searchTitle)) continue;
-
-        const image = await resolveIGDBImage(searchTitle);
-        if (image) {
-          imageMap.set(searchTitle, image);
-        } else {
-          // Short cooldown: the next enrichment pass (triggered by a user
-          // refresh or the site-level 2-hour expiry) will retry.
-          failedImageTitles.set(
-            searchTitle.toLowerCase(),
-            Date.now() + IMAGE_RETRY_AFTER_MS
-          );
-        }
-        // 300ms delay between requests to stay under IGDB rate limit
-        await new Promise(r => setTimeout(r, 300));
-      }
-
-      if (imageMap.size > 0 && cachedRecent) {
-        cachedRecent.results = cachedRecent.results.map((game: Game) => {
-          if (!game.image) {
-            const searchTitle = (game.title as string).trim();
-            const igdbImage = imageMap.get(searchTitle);
-            if (igdbImage) return { ...game, image: igdbImage } as Game;
-          }
-          return game;
-        });
-        console.log(`[Recent] Background enrichment done: ${imageMap.size} images resolved`);
-      } else {
-        console.log(`[Recent] Background enrichment done: no new images`);
-      }
-    } catch (error) {
-      console.error('[Recent] Background enrichment error:', error);
-    } finally {
-      enrichmentRunning = false;
-      // Now that new image URLs have been slotted in, warm the byte cache
-      // for them too.
-      prefetchImageBytesInBackground();
-    }
-  })();
-}
-
-// Background image-byte prefetch — downloads the actual image bytes for every
-// game that has an `image` URL and caches them in memory so the browser's
-// /api/proxy-image requests become near-instant memory hits. This is what
-// stops the browser from having to sit through N FlareSolverr-backed
-// Cloudflare fetches itself.
-function prefetchImageBytesInBackground() {
-  if (imagePrefetchRunning || !cachedRecent) return;
-
-  const urls: string[] = [];
-  for (const g of cachedRecent.results) {
-    const url = g.image;
-    if (typeof url !== 'string' || !url) continue;
-    if (getCachedImage(url)) continue;
-    urls.push(url);
-  }
-  if (urls.length === 0) return;
-
-  imagePrefetchRunning = true;
-  console.log(`[Recent] Background image-byte prefetch starting for ${urls.length} images...`);
-
-  (async () => {
-    try {
-      const cachedCount = await prefetchImageBatch(urls, 3);
-      console.log(`[Recent] Background image-byte prefetch done: ${cachedCount}/${urls.length} cached`);
-    } catch (error) {
-      console.error('[Recent] Background image-byte prefetch error:', error);
-    } finally {
-      imagePrefetchRunning = false;
-    }
-  })();
-}
-
-// Background AppID enrichment — runs after response is sent, fills in Steam
-// AppIDs for any games that didn't have one embedded and aren't already
-// resolved in the resolver cache. Updates cachedRecent.results in-place so
-// subsequent requests return fully-verified data without the client having to
-// do any Steam calls itself.
-function enrichAppIdsInBackground() {
-  if (appIdEnrichmentRunning || !cachedRecent) return;
-
-  pruneFailedTitleMap(failedAppIdTitles);
-
-  const gamesNeedingAppId = cachedRecent.results.filter((g: Game) => {
-    if (hasNativeAppId(g)) return false;
-    const cleanTitle = cleanGameTitle(g.originalTitle || g.title || '').trim();
-    if (!cleanTitle) return false;
-    return shouldRetryTitle(failedAppIdTitles, cleanTitle.toLowerCase());
-  });
-
-  if (gamesNeedingAppId.length === 0) return;
-
-  appIdEnrichmentRunning = true;
-  console.log(`[Recent] Background AppID enrichment starting for ${gamesNeedingAppId.length} games...`);
-
-  (async () => {
-    try {
-      const titles = gamesNeedingAppId.map(g => (g.originalTitle || g.title || '') as string);
-      const resolvedMap = await resolveSteamAppIdsBatch(titles, 6);
-
-      let resolvedCount = 0;
-      if (cachedRecent) {
-        cachedRecent.results = cachedRecent.results.map((game: Game) => {
-          if (hasNativeAppId(game)) return game;
-          const rawTitle = (game.originalTitle || game.title || '') as string;
-          const appId = resolvedMap.get(rawTitle);
-          if (appId) {
-            resolvedCount++;
-            return { ...game, appid: appId } as Game;
-          }
-          const cleanTitle = cleanGameTitle(rawTitle).trim();
-          if (cleanTitle) {
-            failedAppIdTitles.set(
-              cleanTitle.toLowerCase(),
-              Date.now() + APPID_RETRY_AFTER_MS
-            );
-          }
-          return game;
-        });
-      }
-      console.log(`[Recent] Background AppID enrichment done: ${resolvedCount} resolved`);
-    } catch (error) {
-      console.error('[Recent] Background AppID enrichment error:', error);
-    } finally {
-      appIdEnrichmentRunning = false;
-    }
-  })();
+function buildStatsHeader(stats: Record<string, SiteStat>): string {
+  return JSON.stringify(
+    Object.fromEntries(
+      Object.entries(stats).map(([k, s]) => [
+        k,
+        { total: s.total, verified: s.verified, unverified: s.unverified },
+      ])
+    )
+  );
 }
 
 export async function GET(request: NextRequest) {
@@ -233,30 +33,29 @@ export async function GET(request: NextRequest) {
     const site = searchParams.get('site') || 'all';
     const forceRefresh = searchParams.get('refresh') === 'true';
     // Client can ask for a full re-verification pass without re-scraping the
-    // source sites. This clears the per-title failure cooldowns so every
+    // source sites. Clears the per-title failure cooldowns so every
     // unverified game gets another IGDB/Steam attempt on this request's
-    // background enrichment cycle. Useful for the user-facing Refresh button
-    // or a manual `/api/games/recent?reverify=true` call.
+    // background enrichment cycle.
     const forceReverify = searchParams.get('reverify') === 'true';
 
     const now = Date.now();
-    const cacheKey = 'all';
     let results: Game[];
     let isFromCache = false;
+    let manualReverifyRan = false;
 
     if (forceReverify) {
-      failedImageTitles.clear();
-      failedAppIdTitles.clear();
-      const clearedAppIds = clearNegativeAppIdCache();
-      const clearedImages = clearNegativeImageCache();
-      console.log(
-        `[Recent] Reverify requested — cleared cooldowns ` +
-        `(resolver negatives: ${clearedAppIds}, image negatives: ${clearedImages})`
-      );
+      // Manual reverify bypasses the internal cooldown.
+      manualReverifyRan = triggerReverify('manual ?reverify=true', { bypassCooldown: true });
     }
 
-    if (!forceRefresh && cachedRecent && (now - cachedRecent.timestamp) < CACHE_TTL_MS && cachedRecent.siteKey === cacheKey) {
-      results = cachedRecent.results;
+    const cached = getCachedRecent();
+    if (
+      !forceRefresh &&
+      cached &&
+      (now - cached.timestamp) < CACHE_TTL_MS &&
+      cached.siteKey === 'all'
+    ) {
+      results = cached.results;
       isFromCache = true;
 
       // Kick off background re-enrichment for any games still missing images
@@ -266,48 +65,19 @@ export async function GET(request: NextRequest) {
       enrichAppIdsInBackground();
       prefetchImageBytesInBackground();
     } else {
-      const data = await getRecentUploads();
-      
-      if (!data.success || !data.results || !Array.isArray(data.results)) {
-        cachedRecent = null;
-        console.error('Invalid API response structure:', data);
-        return NextResponse.json({ error: 'Invalid API response structure' }, { status: 500 });
+      const { results: fresh, error } = await fetchAndCacheRecent();
+      if (error) {
+        return NextResponse.json({ error }, { status: 500 });
       }
-
-      // Clean titles and seed any Steam AppIDs we already have cached from a
-      // previous run. This means a fresh scrape still returns with many games
-      // already verified (provided they've been seen before) — no client work
-      // required.
-      results = data.results.map((game: Game) => {
-        const originalTitle = game.title;
-        const cleanedTitle = cleanGameTitle(game.title);
-        const next: Game = {
-          ...game,
-          originalTitle,
-          title: cleanedTitle,
-        };
-        if (!hasNativeAppId(next)) {
-          const cached = peekCachedSteamAppId(originalTitle);
-          if (cached) next.appid = cached;
-        }
-        return next;
-      });
-
-      // Reset failure sets on fresh data fetch so previously-failed titles
-      // get another attempt.
-      failedImageTitles.clear();
-      failedAppIdTitles.clear();
-
-      // Cache results immediately so they're available fast
-      cachedRecent = { results, timestamp: now, siteKey: cacheKey };
-
-      // Kick off background enrichment — images and AppIDs will be in cache
-      // for the next request, plus pre-download the raw image bytes so the
-      // user's browser gets instant memory hits from /api/proxy-image.
-      enrichInBackground();
-      enrichAppIdsInBackground();
-      prefetchImageBytesInBackground();
+      results = fresh;
     }
+
+    // Auto-recovery: inspect the just-cached grid for empty sites and for
+    // sites whose verified:unverified ratio is unhealthy, and kick off the
+    // appropriate background actions (per-site rescrape / full reverify).
+    // Rate-limited internally so a persistent upstream failure doesn't put
+    // us in a hot loop.
+    const recovery = runAutoRecovery(results);
 
     // Apply local site filtering
     let finalResults = results;
@@ -315,8 +85,11 @@ export async function GET(request: NextRequest) {
       finalResults = results.filter((game: Game) => game.siteType === site);
     }
 
-    const cacheAge = isFromCache ? Math.floor((now - cachedRecent!.timestamp) / 1000) : 0;
-    const remainingTTL = Math.max(0, Math.floor((CACHE_TTL_MS - (now - (cachedRecent?.timestamp || now))) / 1000));
+    const cachedAfter = getCachedRecent();
+    const cacheAge = isFromCache && cachedAfter ? Math.floor((now - cachedAfter.timestamp) / 1000) : 0;
+    const remainingTTL = cachedAfter
+      ? Math.max(0, Math.floor((CACHE_TTL_MS - (now - cachedAfter.timestamp)) / 1000))
+      : 0;
     const pendingImages = results.filter((g: Game) => !g.image).length;
     const pendingAppIds = results.filter((g: Game) => !hasNativeAppId(g)).length;
 
@@ -333,7 +106,18 @@ export async function GET(request: NextRequest) {
         // warmCache cycle and by on-demand enrichInBackground triggers on
         // every request.
         'X-Pending-Images': pendingImages.toString(),
-        'X-Pending-AppIds': pendingAppIds.toString()
+        'X-Pending-AppIds': pendingAppIds.toString(),
+        // Auto-recovery diagnostics — visible via `curl -I` so operators can
+        // see which sites were empty, which tripped the ratio threshold,
+        // which were actually re-scraped, and whether a reverify ran.
+        'X-Empty-Sites': recovery.emptySites.join(',') || '-',
+        'X-Overloaded-Sites': recovery.overloadedSites.join(',') || '-',
+        'X-Refreshed-Sites': recovery.refreshedSites.join(',') || '-',
+        'X-Reverify-Triggered': (recovery.reverifyTriggered || manualReverifyRan) ? '1' : '0',
+        'X-Reverify-Source': manualReverifyRan
+          ? 'manual'
+          : (recovery.reverifyTriggered ? 'auto-ratio' : '-'),
+        'X-Site-Stats': buildStatsHeader(recovery.stats),
       }
     });
   } catch (error) {

--- a/src/app/api/games/recent/site/[site]/route.ts
+++ b/src/app/api/games/recent/site/[site]/route.ts
@@ -1,0 +1,100 @@
+import { NextResponse, NextRequest } from 'next/server';
+import {
+  computeSiteStats,
+  getCachedRecent,
+  refreshSiteInBackground,
+} from '../../../../../../lib/recentUploadsState';
+
+// Scraping one site through FlareSolverr can take a while on a cold Cloudflare
+// challenge. The refresh itself runs in the background, but we still want a
+// generous ceiling for any synchronous work in this handler.
+export const maxDuration = 120;
+
+interface RouteContext {
+  params: Promise<{ site: string }>;
+}
+
+/**
+ * POST /api/games/recent/site/[site]
+ *
+ * Kicks off a no-cache re-scrape of the named site and merges the fresh
+ * posts into the in-memory recent-uploads grid without touching any other
+ * site. The refresh runs in the background and the response returns
+ * immediately — re-poll `/api/games/recent` a few seconds later to see the
+ * updated data.
+ *
+ * Query params:
+ *   force=true  — bypass the per-site cooldown (SITE_REFRESH_COOLDOWN_MS)
+ *
+ * Body: ignored (kept POST rather than GET so routine browsers and prefetch
+ * heuristics don't accidentally trigger re-scrapes).
+ */
+export async function POST(request: NextRequest, context: RouteContext) {
+  const { site } = await context.params;
+  const { searchParams } = new URL(request.url);
+  const bypassCooldown = searchParams.get('force') === 'true';
+
+  const result = refreshSiteInBackground(site, {
+    bypassCooldown,
+    reason: 'manual endpoint',
+  });
+
+  const cached = getCachedRecent();
+  const stats = cached ? computeSiteStats(cached.results) : null;
+  const siteStats = stats?.[site] ?? null;
+
+  if (!result.started) {
+    const code = result.reason === 'unknown-site' ? 404 : 202;
+    return NextResponse.json(
+      {
+        success: false,
+        site,
+        started: false,
+        reason: result.reason,
+        siteStats,
+      },
+      { status: code }
+    );
+  }
+
+  return NextResponse.json({
+    success: true,
+    site,
+    started: true,
+    bypassCooldown,
+    siteStats,
+    message: `Refresh started for ${site}; re-poll /api/games/recent in a few seconds to see merged results.`,
+  });
+}
+
+/**
+ * GET /api/games/recent/site/[site]
+ *
+ * Lightweight introspection — returns the current cached-grid stats for this
+ * site (total / verified / unverified counts). Useful for operators and for
+ * the client if we ever want to expose per-site health in the UI.
+ */
+export async function GET(_request: NextRequest, context: RouteContext) {
+  const { site } = await context.params;
+  const cached = getCachedRecent();
+  const stats = cached ? computeSiteStats(cached.results) : null;
+  const siteStats = stats?.[site] ?? null;
+
+  if (!siteStats) {
+    return NextResponse.json(
+      {
+        success: false,
+        site,
+        siteStats: null,
+        error: cached ? `no stats for site: ${site}` : 'cache not populated yet',
+      },
+      { status: cached ? 404 : 503 }
+    );
+  }
+
+  return NextResponse.json({
+    success: true,
+    site,
+    siteStats,
+  });
+}

--- a/src/lib/gameapi/index.ts
+++ b/src/lib/gameapi/index.ts
@@ -325,6 +325,55 @@ export async function getRecentUploads(): Promise<RecentResult> {
 }
 
 /**
+ * Fetch recent uploads from a single site. Used by the per-site refresh
+ * endpoint and the auto-recovery logic in /api/games/recent that detects
+ * empty/stale sites and refreshes just those without a full bulk rescrape.
+ *
+ * Returns the (possibly empty) posts array from that one site. Does not
+ * touch any in-memory cache on its own — the caller is responsible for
+ * merging the fresh results back into whatever cache it owns.
+ */
+export async function getRecentUploadsForSite(
+  siteKey: string
+): Promise<{ success: boolean; site: string; results: TransformedPost[]; count: number; error?: string }> {
+  const siteConfig = SITE_CONFIGS[siteKey] as SiteConfig | undefined;
+  if (!siteConfig) {
+    return { success: false, site: siteKey, results: [], count: 0, error: `Invalid site: ${siteKey}` };
+  }
+
+  try {
+    const results = await fetchRecentFromSite(siteConfig);
+    return { success: true, site: siteKey, results, count: results.length };
+  } catch (error) {
+    console.error(`Error fetching recent from ${siteConfig.name}:`, error);
+    return {
+      success: false,
+      site: siteKey,
+      results: [],
+      count: 0,
+      error: error instanceof Error ? error.message : 'Unknown error',
+    };
+  }
+}
+
+/**
+ * List of site keys the gameapi knows about. Exposed so callers (like the
+ * /api/games/recent auto-refresh logic) can iterate over every site without
+ * hard-coding the list here.
+ */
+export function listSiteKeys(): string[] {
+  return Object.keys(SITE_CONFIGS);
+}
+
+/**
+ * Lookup the human-readable `name` for a site key, or `null` if unknown.
+ */
+export function getSiteDisplayName(siteKey: string): string | null {
+  const siteConfig = SITE_CONFIGS[siteKey] as SiteConfig | undefined;
+  return siteConfig?.name ?? null;
+}
+
+/**
  * Fetch details and download links for a specific post.
  */
 export async function getPostDetails(postId: string, site: string): Promise<PostResult> {

--- a/src/lib/recentUploadsState.ts
+++ b/src/lib/recentUploadsState.ts
@@ -1,0 +1,522 @@
+/**
+ * Shared in-memory state and background-enrichment primitives for the
+ * /api/games/recent route and any sibling routes that want to mutate the
+ * cached grid (e.g. the per-site refresh endpoint).
+ *
+ * Next.js App Router's `route.ts` files are not allowed to export helpers
+ * beyond the HTTP verbs, so this module holds the cache, enrichment queues,
+ * per-site refresh scheduling, and auto-recovery logic that used to live
+ * inside the route handler.
+ */
+
+import { cleanGameTitle } from '../utils/steamApi';
+import { resolveIGDBImage, clearNegativeImageCache } from '../utils/igdb';
+import {
+  getRecentUploads,
+  getRecentUploadsForSite,
+  listSiteKeys,
+  getSiteDisplayName,
+} from './gameapi';
+import {
+  peekCachedSteamAppId,
+  resolveSteamAppIdsBatch,
+  clearNegativeAppIdCache,
+} from '../utils/steamAppIdResolver';
+import { prefetchImageBatch, getCachedImage } from '../utils/imageCache';
+
+// ─── Types ─────────────────────────────────────────────────────────────────
+
+export interface Game {
+  siteType: string;
+  id: string;
+  title: string;
+  originalTitle?: string;
+  source: string;
+  appid?: number | string;
+  appId?: number | string;
+  steamAppId?: number | string;
+  steam_appid?: number | string;
+  [key: string]: unknown;
+}
+
+export interface SiteStat {
+  total: number;
+  verified: number;
+  unverified: number;
+  /** verified / unverified, or Infinity if there are no unverified posts. */
+  ratio: number;
+}
+
+export interface AutoRecoveryReport {
+  stats: Record<string, SiteStat>;
+  emptySites: string[];
+  overloadedSites: string[];
+  refreshedSites: string[];
+  reverifyTriggered: boolean;
+}
+
+// ─── Cache state ───────────────────────────────────────────────────────────
+
+interface CachedRecent {
+  results: Game[];
+  timestamp: number;
+  siteKey: string;
+}
+
+let cachedRecent: CachedRecent | null = null;
+export const CACHE_TTL_MS = 2 * 60 * 60 * 1000; // 2 hours
+
+export function getCachedRecent(): CachedRecent | null {
+  return cachedRecent;
+}
+
+export function setCachedRecent(next: CachedRecent | null): void {
+  cachedRecent = next;
+}
+
+// ─── Per-title failure cooldowns ───────────────────────────────────────────
+
+const failedImageTitles = new Map<string, number>();
+const failedAppIdTitles = new Map<string, number>();
+
+const IMAGE_RETRY_AFTER_MS = 10 * 60 * 1000; // 10m — aligned with IMAGE_MISS_TTL in utils/igdb.ts
+const APPID_RETRY_AFTER_MS = 2 * 60 * 1000; //  2m — short enough for a few refreshes to pick up
+//                                                 anything whose resolver cache has expired.
+
+function shouldRetryTitle(map: Map<string, number>, key: string): boolean {
+  const until = map.get(key);
+  if (!until) return true;
+  if (Date.now() >= until) {
+    map.delete(key);
+    return true;
+  }
+  return false;
+}
+
+function pruneFailedTitleMap(map: Map<string, number>): void {
+  const now = Date.now();
+  for (const [key, until] of map) {
+    if (now >= until) map.delete(key);
+  }
+}
+
+export function clearFailureCooldowns(): void {
+  failedImageTitles.clear();
+  failedAppIdTitles.clear();
+}
+
+// ─── Auto-recovery tunables ────────────────────────────────────────────────
+
+export const UNVERIFIED_TRIGGER = Math.max(
+  1,
+  parseInt(process.env.RECENT_UNVERIFIED_TRIGGER || '10', 10) || 10
+);
+export const VERIFIED_RATIO = (() => {
+  const raw = parseFloat(process.env.RECENT_VERIFIED_RATIO || '2');
+  return Number.isFinite(raw) && raw > 0 ? raw : 2;
+})();
+const SITE_REFRESH_COOLDOWN_MS = Math.max(
+  30_000,
+  parseInt(process.env.RECENT_SITE_REFRESH_COOLDOWN_MS || '300000', 10) || 300_000
+);
+const REVERIFY_COOLDOWN_MS = Math.max(
+  30_000,
+  parseInt(process.env.RECENT_REVERIFY_COOLDOWN_MS || '300000', 10) || 300_000
+);
+
+const lastSiteRefreshAt = new Map<string, number>();
+let lastReverifyAt = 0;
+const inflightSiteRefreshes = new Set<string>();
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
+
+export function hasNativeAppId(game: Game): boolean {
+  const candidates = [game.appid, game.appId, game.steamAppId, game.steam_appid];
+  return candidates.some(c => c !== undefined && c !== null && /^\d+$/.test(String(c).trim()));
+}
+
+// ─── Background enrichment ─────────────────────────────────────────────────
+
+let enrichmentRunning = false;
+let appIdEnrichmentRunning = false;
+let imagePrefetchRunning = false;
+
+export function enrichInBackground(): void {
+  if (enrichmentRunning || !cachedRecent) return;
+
+  pruneFailedTitleMap(failedImageTitles);
+
+  const gamesNeedingImages = cachedRecent.results.filter((g: Game) => {
+    if (g.image) return false;
+    const searchTitle = (g.title as string).trim();
+    if (!searchTitle) return false;
+    return shouldRetryTitle(failedImageTitles, searchTitle.toLowerCase());
+  });
+
+  if (gamesNeedingImages.length === 0) return;
+
+  enrichmentRunning = true;
+  console.log(`[Recent] Background enrichment starting for ${gamesNeedingImages.length} games...`);
+
+  (async () => {
+    try {
+      const imageMap = new Map<string, string>();
+      for (const game of gamesNeedingImages) {
+        const searchTitle = (game.title as string).trim();
+        if (!searchTitle || imageMap.has(searchTitle)) continue;
+
+        const image = await resolveIGDBImage(searchTitle);
+        if (image) {
+          imageMap.set(searchTitle, image);
+        } else {
+          failedImageTitles.set(
+            searchTitle.toLowerCase(),
+            Date.now() + IMAGE_RETRY_AFTER_MS
+          );
+        }
+        // 300ms delay between requests to stay under IGDB rate limit
+        await new Promise(r => setTimeout(r, 300));
+      }
+
+      if (imageMap.size > 0 && cachedRecent) {
+        cachedRecent.results = cachedRecent.results.map((game: Game) => {
+          if (!game.image) {
+            const searchTitle = (game.title as string).trim();
+            const igdbImage = imageMap.get(searchTitle);
+            if (igdbImage) return { ...game, image: igdbImage } as Game;
+          }
+          return game;
+        });
+        console.log(`[Recent] Background enrichment done: ${imageMap.size} images resolved`);
+      } else {
+        console.log(`[Recent] Background enrichment done: no new images`);
+      }
+    } catch (error) {
+      console.error('[Recent] Background enrichment error:', error);
+    } finally {
+      enrichmentRunning = false;
+      prefetchImageBytesInBackground();
+    }
+  })();
+}
+
+export function prefetchImageBytesInBackground(): void {
+  if (imagePrefetchRunning || !cachedRecent) return;
+
+  const urls: string[] = [];
+  for (const g of cachedRecent.results) {
+    const url = g.image;
+    if (typeof url !== 'string' || !url) continue;
+    if (getCachedImage(url)) continue;
+    urls.push(url);
+  }
+  if (urls.length === 0) return;
+
+  imagePrefetchRunning = true;
+  console.log(`[Recent] Background image-byte prefetch starting for ${urls.length} images...`);
+
+  (async () => {
+    try {
+      const cachedCount = await prefetchImageBatch(urls, 3);
+      console.log(`[Recent] Background image-byte prefetch done: ${cachedCount}/${urls.length} cached`);
+    } catch (error) {
+      console.error('[Recent] Background image-byte prefetch error:', error);
+    } finally {
+      imagePrefetchRunning = false;
+    }
+  })();
+}
+
+export function enrichAppIdsInBackground(): void {
+  if (appIdEnrichmentRunning || !cachedRecent) return;
+
+  pruneFailedTitleMap(failedAppIdTitles);
+
+  const gamesNeedingAppId = cachedRecent.results.filter((g: Game) => {
+    if (hasNativeAppId(g)) return false;
+    const cleanTitle = cleanGameTitle(g.originalTitle || g.title || '').trim();
+    if (!cleanTitle) return false;
+    return shouldRetryTitle(failedAppIdTitles, cleanTitle.toLowerCase());
+  });
+
+  if (gamesNeedingAppId.length === 0) return;
+
+  appIdEnrichmentRunning = true;
+  console.log(`[Recent] Background AppID enrichment starting for ${gamesNeedingAppId.length} games...`);
+
+  (async () => {
+    try {
+      const titles = gamesNeedingAppId.map(g => (g.originalTitle || g.title || '') as string);
+      const resolvedMap = await resolveSteamAppIdsBatch(titles, 6);
+
+      let resolvedCount = 0;
+      if (cachedRecent) {
+        cachedRecent.results = cachedRecent.results.map((game: Game) => {
+          if (hasNativeAppId(game)) return game;
+          const rawTitle = (game.originalTitle || game.title || '') as string;
+          const appId = resolvedMap.get(rawTitle);
+          if (appId) {
+            resolvedCount++;
+            return { ...game, appid: appId } as Game;
+          }
+          const cleanTitle = cleanGameTitle(rawTitle).trim();
+          if (cleanTitle) {
+            failedAppIdTitles.set(
+              cleanTitle.toLowerCase(),
+              Date.now() + APPID_RETRY_AFTER_MS
+            );
+          }
+          return game;
+        });
+      }
+      console.log(`[Recent] Background AppID enrichment done: ${resolvedCount} resolved`);
+    } catch (error) {
+      console.error('[Recent] Background AppID enrichment error:', error);
+    } finally {
+      appIdEnrichmentRunning = false;
+    }
+  })();
+}
+
+// ─── Bulk fetch ────────────────────────────────────────────────────────────
+
+export async function fetchAndCacheRecent(): Promise<{ results: Game[]; error?: string }> {
+  const data = await getRecentUploads();
+
+  if (!data.success || !data.results || !Array.isArray(data.results)) {
+    cachedRecent = null;
+    console.error('Invalid API response structure:', data);
+    return { results: [], error: 'Invalid API response structure' };
+  }
+
+  const results: Game[] = data.results.map((game: unknown) => {
+    const g = game as Game;
+    const originalTitle = g.title;
+    const cleanedTitle = cleanGameTitle(g.title);
+    const next: Game = {
+      ...g,
+      originalTitle,
+      title: cleanedTitle,
+    };
+    if (!hasNativeAppId(next)) {
+      const cached = peekCachedSteamAppId(originalTitle);
+      if (cached) next.appid = cached;
+    }
+    return next;
+  });
+
+  // Reset failure sets on fresh data fetch so previously-failed titles get
+  // another attempt.
+  clearFailureCooldowns();
+
+  cachedRecent = { results, timestamp: Date.now(), siteKey: 'all' };
+
+  enrichInBackground();
+  enrichAppIdsInBackground();
+  prefetchImageBytesInBackground();
+
+  return { results };
+}
+
+// ─── Per-site stats ────────────────────────────────────────────────────────
+
+export function computeSiteStats(games: Game[]): Record<string, SiteStat> {
+  const stats: Record<string, SiteStat> = {};
+  for (const key of listSiteKeys()) {
+    stats[key] = { total: 0, verified: 0, unverified: 0, ratio: Infinity };
+  }
+
+  for (const game of games) {
+    const siteKey = String(game.siteType || '').trim();
+    if (!siteKey) continue;
+    if (!stats[siteKey]) {
+      stats[siteKey] = { total: 0, verified: 0, unverified: 0, ratio: Infinity };
+    }
+    stats[siteKey].total += 1;
+    if (hasNativeAppId(game)) {
+      stats[siteKey].verified += 1;
+    } else {
+      stats[siteKey].unverified += 1;
+    }
+  }
+
+  for (const key of Object.keys(stats)) {
+    const s = stats[key];
+    s.ratio = s.unverified === 0 ? Infinity : s.verified / s.unverified;
+  }
+
+  return stats;
+}
+
+export function findEmptySiteKeys(stats: Record<string, SiteStat>): string[] {
+  return Object.keys(stats).filter(k => stats[k].total === 0);
+}
+
+export function findOverloadedSiteKeys(stats: Record<string, SiteStat>): string[] {
+  const overloaded: string[] = [];
+  for (const [key, s] of Object.entries(stats)) {
+    if (s.unverified >= UNVERIFIED_TRIGGER && s.ratio < VERIFIED_RATIO) {
+      overloaded.push(key);
+    }
+  }
+  return overloaded;
+}
+
+// ─── Per-site background refresh ───────────────────────────────────────────
+
+export interface RefreshSiteOptions {
+  /** Skip the rate-limit check. Used by the on-demand endpoint. */
+  bypassCooldown?: boolean;
+  /** Free-form reason string logged for diagnostics. */
+  reason?: string;
+}
+
+export interface RefreshSiteResult {
+  started: boolean;
+  reason?: string;
+}
+
+export function refreshSiteInBackground(
+  siteKey: string,
+  opts: RefreshSiteOptions = {}
+): RefreshSiteResult {
+  const siteName = getSiteDisplayName(siteKey);
+  if (!siteName) {
+    return { started: false, reason: 'unknown-site' };
+  }
+
+  if (inflightSiteRefreshes.has(siteKey)) {
+    return { started: false, reason: 'already-in-flight' };
+  }
+
+  const lastAt = lastSiteRefreshAt.get(siteKey) || 0;
+  const elapsed = Date.now() - lastAt;
+  if (!opts.bypassCooldown && elapsed < SITE_REFRESH_COOLDOWN_MS) {
+    const remaining = Math.ceil((SITE_REFRESH_COOLDOWN_MS - elapsed) / 1000);
+    return { started: false, reason: `cooldown-${remaining}s` };
+  }
+
+  inflightSiteRefreshes.add(siteKey);
+  lastSiteRefreshAt.set(siteKey, Date.now());
+
+  console.log(
+    `[Recent] Per-site refresh starting for ${siteName} (${siteKey})` +
+      (opts.reason ? ` — reason: ${opts.reason}` : '')
+  );
+
+  (async () => {
+    try {
+      const result = await getRecentUploadsForSite(siteKey);
+      if (!result.success) {
+        console.warn(
+          `[Recent] Per-site refresh for ${siteName} failed: ${result.error || 'unknown error'}`
+        );
+        return;
+      }
+
+      // Seed AppIDs we already have cached, just like the bulk path does.
+      const freshResults: Game[] = result.results.map((game) => {
+        const g = game as unknown as Game;
+        const originalTitle = (g.title as string) || '';
+        const cleanedTitle = cleanGameTitle(originalTitle);
+        const next: Game = {
+          ...g,
+          originalTitle,
+          title: cleanedTitle,
+        };
+        if (!hasNativeAppId(next)) {
+          const cached = peekCachedSteamAppId(originalTitle);
+          if (cached) next.appid = cached;
+        }
+        return next;
+      });
+
+      if (!cachedRecent) {
+        console.log(
+          `[Recent] Per-site refresh for ${siteName} produced ${freshResults.length} posts ` +
+            `but cache is empty; skipping merge (will be picked up on next full fetch).`
+        );
+        return;
+      }
+
+      // Replace every entry for this site with the fresh set, keep everything
+      // else untouched, then resort by date so the grid stays chronological.
+      const prevCount = cachedRecent.results.filter((g) => g.siteType === siteKey).length;
+      const kept = cachedRecent.results.filter((g) => g.siteType !== siteKey);
+      const merged = [...kept, ...freshResults].sort((a, b) => {
+        const da = a.date ? new Date(a.date as string).getTime() : 0;
+        const db = b.date ? new Date(b.date as string).getTime() : 0;
+        return db - da;
+      });
+      cachedRecent = {
+        results: merged,
+        timestamp: cachedRecent.timestamp,
+        siteKey: cachedRecent.siteKey,
+      };
+
+      console.log(
+        `[Recent] Per-site refresh done for ${siteName}: replaced ${prevCount} → ${freshResults.length} posts`
+      );
+
+      enrichInBackground();
+      enrichAppIdsInBackground();
+      prefetchImageBytesInBackground();
+    } catch (err) {
+      console.error(`[Recent] Per-site refresh error for ${siteName}:`, err);
+    } finally {
+      inflightSiteRefreshes.delete(siteKey);
+    }
+  })();
+
+  return { started: true };
+}
+
+// ─── Reverify ──────────────────────────────────────────────────────────────
+
+/**
+ * Clear per-title failure cooldowns and both helper modules' negative
+ * caches so every unverified title gets another IGDB/Steam attempt. Rate
+ * limited by `REVERIFY_COOLDOWN_MS`. Returns `true` if the reverify was
+ * actually executed.
+ */
+export function triggerReverify(reason: string, opts: { bypassCooldown?: boolean } = {}): boolean {
+  const elapsed = Date.now() - lastReverifyAt;
+  if (!opts.bypassCooldown && elapsed < REVERIFY_COOLDOWN_MS) return false;
+  lastReverifyAt = Date.now();
+
+  clearFailureCooldowns();
+  const clearedAppIds = clearNegativeAppIdCache();
+  const clearedImages = clearNegativeImageCache();
+  console.log(
+    `[Recent] Reverify triggered (${reason}) — cleared ` +
+      `route cooldowns, resolver negatives: ${clearedAppIds}, image negatives: ${clearedImages}`
+  );
+
+  enrichInBackground();
+  enrichAppIdsInBackground();
+  return true;
+}
+
+// ─── Auto-recovery ─────────────────────────────────────────────────────────
+
+export function runAutoRecovery(games: Game[]): AutoRecoveryReport {
+  const stats = computeSiteStats(games);
+  const emptySites = findEmptySiteKeys(stats);
+  const overloadedSites = findOverloadedSiteKeys(stats);
+
+  const refreshedSites: string[] = [];
+  for (const siteKey of emptySites) {
+    const { started } = refreshSiteInBackground(siteKey, { reason: 'empty-site' });
+    if (started) refreshedSites.push(siteKey);
+  }
+
+  const reverifyTriggered =
+    overloadedSites.length > 0 &&
+    triggerReverify(
+      `overloaded sites: ${overloadedSites
+        .map(s => `${s}=${stats[s].verified}v/${stats[s].unverified}u`)
+        .join(', ')}`
+    );
+
+  return { stats, emptySites, overloadedSites, refreshedSites, reverifyTriggered };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Three new pieces of server-side plumbing on top of the existing `/api/games/recent` cache:

### 1. Empty-site refresh

Every time a user (or the scheduler) hits `/api/games/recent`, we compute per-site post counts. Any site with **0 posts** in the cached grid gets an immediate no-cache re-scrape of just that site, without waiting for the 25-minute `scheduler.warmCache` cycle or the 2-hour full-cache expiry. The fresh posts are merged back into the grid (replacing that site's previous entries only), the grid is resorted by date, and enrichment runs for the new posts. No bulk re-scrape required.

### 2. Verified-to-unverified ratio guard

Each request also computes per-site `verified` (has a Steam AppID) vs. `unverified` post counts. If any site has at least `RECENT_UNVERIFIED_TRIGGER` unverified posts (default **10**) **and** its verified:unverified ratio falls below `RECENT_VERIFIED_RATIO` (default **2** — i.e. we expect at least twice as many verified as unverified), a reverify pass fires in the background:

- Per-title negative cooldowns in the recent route are cleared.
- `clearNegativeAppIdCache()` from the Steam resolver runs.
- `clearNegativeImageCache()` from the IGDB/RAWG helper runs.
- Both enrichment queues re-run.

Positive AppID/image hits are preserved. The ideal 20:1 target is configurable — set `RECENT_VERIFIED_RATIO=20` to enforce it.

Both actions are rate-limited internally (default 5-minute cooldowns) so a persistent upstream failure can't put us in a hot loop.

### 3. New endpoint — per-site on-demand refresh

```
POST /api/games/recent/site/{site}       # kick off a no-cache rescrape of that site
POST /api/games/recent/site/{site}?force=true    # bypass the per-site cooldown
GET  /api/games/recent/site/{site}       # current stats for the site
```

Refresh runs in the background; the response returns immediately with whether the refresh was started (`200`), skipped due to cooldown (`202` with `reason: 'cooldown-40s'`), the site is unknown (`404`), or the cache isn't warm yet (`503`).

This lets operators (or a future admin UI) rescrape just **one** site instead of the existing bulk `?refresh=true`.

## New response headers on `/api/games/recent`

All visible via `curl -I http://localhost:3000/api/games/recent`:

- `X-Empty-Sites` — comma-separated keys of sites with 0 posts.
- `X-Overloaded-Sites` — comma-separated keys of sites tripping the ratio threshold.
- `X-Refreshed-Sites` — which empty sites actually had background refreshes started (vs. rate-limited).
- `X-Reverify-Triggered` — `1`/`0`.
- `X-Reverify-Source` — `auto-ratio`, `manual`, or `-`.
- `X-Site-Stats` — JSON: `{"<site>": {"total": N, "verified": N, "unverified": N}, …}`.

## Refactor

Next.js App Router's `route.ts` files can't export arbitrary helpers alongside the HTTP verbs, so all in-memory state and background-enrichment primitives moved to a new `src/lib/recentUploadsState.ts` module. Both `/api/games/recent/route.ts` and `/api/games/recent/site/[site]/route.ts` import from there.

New helpers in `src/lib/gameapi/index.ts`:

- `getRecentUploadsForSite(siteKey)` — scrapes one site, returns its posts (no caching).
- `listSiteKeys()`
- `getSiteDisplayName(siteKey)`

## Env knobs (all documented in `.env.example`)

| Var | Default | Purpose |
|---|---|---|
| `RECENT_UNVERIFIED_TRIGGER` | `10` | Min unverified posts for a site to be considered for reverify. |
| `RECENT_VERIFIED_RATIO` | `2` | Min acceptable verified:unverified ratio. Set to `20` for the ideal 20:1. |
| `RECENT_SITE_REFRESH_COOLDOWN_MS` | `300000` | Per-site background refresh cooldown. The endpoint's `?force=true` bypasses it. |
| `RECENT_REVERIFY_COOLDOWN_MS` | `300000` | Reverify cooldown. The route's `?reverify=true` bypasses it. |

## Verification

Smoke-tested against `npx next dev` on `localhost:3000`:

```
$ curl -I 'http://localhost:3000/api/games/recent'
HTTP/1.1 200 OK
x-cache-status: MISS
x-empty-sites: skidrow,onlinefix,goggames,dodi
x-overloaded-sites: freegog,gamedrive,steamrip,reloadedsteam,steamunderground
x-pending-appids: 170
x-refreshed-sites: skidrow,onlinefix,goggames,dodi
x-reverify-triggered: 1
x-reverify-source: auto-ratio
x-site-stats: {"skidrow":{"total":0,…},"freegog":{"total":10,"verified":0,"unverified":10},…}

$ # …a few seconds later, after background enrichment…
$ curl -I 'http://localhost:3000/api/games/recent'
x-cache-status: HIT
x-overloaded-sites: -
x-pending-appids: 10          # down from 170
x-reverify-triggered: 0
x-site-stats: {"freegog":{"total":10,"verified":10,…},"steamrip":{"total":40,"verified":39,"unverified":1},…}

$ curl -X POST 'http://localhost:3000/api/games/recent/site/steamrip?force=true'
{"success":true,"site":"steamrip","started":true,"bypassCooldown":true,"siteStats":{"total":40,"verified":39,"unverified":1,"ratio":39},…}

$ curl -X POST 'http://localhost:3000/api/games/recent/site/steamrip'   # no force
{"success":false,"reason":"cooldown-40s",…}  # HTTP 202

$ curl -X POST 'http://localhost:3000/api/games/recent/site/nonexistent'
{"success":false,"reason":"unknown-site",…}  # HTTP 404
```

Server log during the test confirmed the end-to-end round trip:

```
[Recent] Background AppID enrichment done: 160 resolved
```

- `npx tsc --noEmit` clean.
- `npx eslint` clean on all changed files.
- `npx next build --turbopack` succeeds; both routes registered:
  ```
  ├ ƒ /api/games/recent                      0 B            0 B
  ├ ƒ /api/games/recent/site/[site]          0 B            0 B
  ```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0855bb2e-be36-47c1-8855-619e7d9ee159"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0855bb2e-be36-47c1-8855-619e7d9ee159"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

