### PR TITLE
Persistent page layout prefs + game API refinements

### DIFF
--- a/src/app/api/games/downloads/route.ts
+++ b/src/app/api/games/downloads/route.ts
@@ -7,6 +7,10 @@ import {
   fetchDownloadLinksViaGameapi,
   type TrackedDownloadLink
 } from '../../../../lib/trackedGameDownloadLinks';
+import {
+  buildDodiFollowPostDownloadResponse,
+  isDodiTrackedGame,
+} from '../../../../lib/downloadSitePolicy';
 
 // GET: Get download links for a specific game or update
 export async function GET(req: NextRequest) {
@@ -42,6 +46,17 @@ export async function GET(req: NextRequest) {
         { error: 'Game not found or access denied' },
         { status: 404 }
       );
+    }
+
+    if (isDodiTrackedGame(game)) {
+      return NextResponse.json({
+        gameId: game._id,
+        ...buildDodiFollowPostDownloadResponse({
+          title: game.title,
+          gameLink: game.gameLink,
+          lastKnownVersion: game.lastKnownVersion,
+        }),
+      });
     }
 
     let downloadLinks: TrackedDownloadLink[] = [];

--- a/src/app/api/games/links/route.ts
+++ b/src/app/api/games/links/route.ts
@@ -1,5 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getPostDetails } from '../../../../lib/gameapi';
+import {
+  buildDodiFollowPostDownloadResponse,
+  isDodiSiteType,
+} from '../../../../lib/downloadSitePolicy';
 
 // In-memory cache for gameapi download link responses
 const linksCache = new Map<string, { data: unknown; timestamp: number }>();
@@ -13,12 +17,26 @@ export async function GET(req: NextRequest) {
     const postId = searchParams.get('postId');
     const siteType = searchParams.get('siteType');
     const gameTitle = searchParams.get('title');
+    const postUrlParam = searchParams.get('postUrl') || searchParams.get('link') || '';
 
     if (!postId || !siteType) {
       return NextResponse.json(
         { error: 'postId and siteType are required' },
         { status: 400 }
       );
+    }
+
+    if (isDodiSiteType(siteType)) {
+      return NextResponse.json({
+        postId,
+        siteType,
+        ...buildDodiFollowPostDownloadResponse({
+          title: gameTitle || 'Unknown Game',
+          gameLink:
+            postUrlParam ||
+            `https://dodi-repacks.site/?p=${encodeURIComponent(postId)}`,
+        }),
+      });
     }
 
     try {

--- a/src/app/api/games/search/route.ts
+++ b/src/app/api/games/search/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { cleanGameTitle } from '../../../../utils/steamApi';
+import { filterGamesBySearchQuery } from '../../../../utils/searchQueryFilter';
 import { searchGames } from '../../../../lib/gameapi';
 import { peekCachedSteamAppId, resolveSteamAppIdsBatch } from '../../../../utils/steamAppIdResolver';
 import { isCfProtectedUrl, prefetchImageBatch } from '../../../../utils/imageCache';
@@ -141,6 +142,14 @@ export async function GET(request: NextRequest) {
         if (!shouldUseSteamHeader) return game;
         return { ...game, image: steamHeaderImageUrl(appId) };
       });
+
+      const beforeTermFilter = results.length;
+      results = filterGamesBySearchQuery(results, search);
+      if (beforeTermFilter > results.length) {
+        console.log(
+          `[Search] Term filter removed ${beforeTermFilter - results.length} result(s) for "${search}"`
+        );
+      }
 
       searchCache.set(cacheKey, {
         data: results,

--- a/src/app/api/updates/check/route.ts
+++ b/src/app/api/updates/check/route.ts
@@ -60,6 +60,10 @@ async function fetchDownloadLinks(game: GameSearchResult): Promise<Array<{ servi
       logger.warn(`Invalid game ID format: ${game.id}`);
       return [];
     }
+
+    if (siteType === 'dodi') {
+      return [];
+    }
     
     logger.debug(`Fetching download links for: ${siteType}/${originalId}`);
     

--- a/src/app/api/user/preferences/route.ts
+++ b/src/app/api/user/preferences/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '../../../../lib/auth-options';
+import connectDB from '../../../../lib/db';
+import { User } from '../../../../lib/models';
+
+type GridSizeInput = number | 'auto' | null | undefined;
+
+function normalizeGridSize(value: GridSizeInput): number | 'auto' | undefined {
+  if (value === 'auto' || value === null || value === undefined) return 'auto';
+  const n = Number(value);
+  if (!Number.isNaN(n) && n >= 1 && n <= 12) return n;
+  return undefined;
+}
+
+function normalizeLayoutMode(value: unknown): 'grid' | 'horizontal' | undefined {
+  return value === 'grid' || value === 'horizontal' ? value : undefined;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function applyLayoutFields(target: Record<string, any>, source: Record<string, unknown>) {
+  const layoutMode = normalizeLayoutMode(source.layoutMode);
+  const customCols = normalizeGridSize(source.customCols as GridSizeInput);
+  const customRows = normalizeGridSize(source.customRows as GridSizeInput);
+  if (layoutMode) target.layoutMode = layoutMode;
+  if (customCols !== undefined) target.customCols = customCols;
+  if (customRows !== undefined) target.customRows = customRows;
+}
+
+export async function PATCH(req: Request) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const body = await req.json();
+    const { homepage, tracking } = body ?? {};
+
+    await connectDB();
+    const user = await User.findById(session.user.id);
+    if (!user) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    }
+
+    user.preferences = user.preferences || {};
+
+    if (homepage && typeof homepage === 'object') {
+      user.preferences.homepage = user.preferences.homepage || {};
+      applyLayoutFields(user.preferences.homepage, homepage as Record<string, unknown>);
+      if (typeof homepage.showRecentUploads === 'boolean') {
+        user.preferences.homepage.showRecentUploads = homepage.showRecentUploads;
+      }
+      if (typeof homepage.showAllGames === 'boolean') {
+        user.preferences.homepage.showAllGames = homepage.showAllGames;
+      }
+    }
+
+    if (tracking && typeof tracking === 'object') {
+      user.preferences.tracking = user.preferences.tracking || {};
+      applyLayoutFields(user.preferences.tracking, tracking as Record<string, unknown>);
+    }
+
+    await user.save();
+
+    return NextResponse.json({
+      success: true,
+      preferences: {
+        homepage: user.preferences.homepage,
+        tracking: user.preferences.tracking,
+      },
+    });
+  } catch (error) {
+    console.error('PATCH /api/user/preferences error', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,6 +10,9 @@ import { useConfirm } from '../contexts/ConfirmContext';
 import { SITES } from '../lib/sites';
 import { cleanGameTitle } from '../utils/steamApi';
 import { getProxiedImageUrl } from '../utils/imageProxy';
+import { PageLayoutSettings } from '../components/PageLayoutSettings';
+import { usePersistedHomepagePreferences } from '../hooks/usePersistedPagePreferences';
+import { buildCustomGridStyle } from '../utils/pagePreferences';
 
 type TrackedGameInfo = {
   trackedId: string;
@@ -65,8 +68,29 @@ function DashboardInner() {
   const searchParams = useSearchParams();
   const [refineText, setRefineText] = useState('');
   const [showRefine, setShowRefine] = useState(false);
-  const [showRecentGames, setShowRecentGames] = useState(false);
-  const [showAllGames, setShowAllGames] = useState(false);
+  const homepagePrefs = usePersistedHomepagePreferences(status === 'authenticated');
+  const {
+    layoutMode,
+    setLayoutMode,
+    customCols,
+    setCustomCols,
+    customRows,
+    setCustomRows,
+    showLayoutDropdown,
+    setShowLayoutDropdown,
+    showRecentGames,
+    setRecentGamesVisible,
+    showAllGames,
+    setShowAllGames,
+  } = homepagePrefs;
+
+  const customGridStyle = buildCustomGridStyle(layoutMode, customCols, customRows);
+  const defaultGridClass =
+    layoutMode === 'grid' && customCols === 'auto'
+      ? 'grid grid-cols-2 md:grid-cols-5 gap-4 sm:gap-6'
+      : layoutMode === 'grid'
+        ? 'grid gap-4 sm:gap-6'
+        : 'flex flex-row gap-4 sm:gap-6 overflow-x-auto pb-4 snap-x snap-mandatory';
 
   // Single AbortController tied to this component's lifetime. We abort it on
   // unmount so pending fetches (e.g. the up-to-120s /api/games/recent scrape)
@@ -199,7 +223,7 @@ function DashboardInner() {
             if (signal.aborted) return;
             setGames(data);
             setShowRefine(true);
-            setRecentGamesCookie(true);
+            setRecentGamesVisible(true);
           } catch (err) {
             if ((err as { name?: string })?.name === 'AbortError') return;
             setError(err instanceof Error ? err.message : 'Failed to search games');
@@ -214,16 +238,6 @@ function DashboardInner() {
       return () => clearTimeout(timer);
     }
   }, [searchParams, getFetchSignal]);
-
-  // Function to set cookie with 1 hour expiration
-  const setRecentGamesCookie = (show: boolean) => {
-    const expires = new Date();
-    expires.setTime(expires.getTime() + (60 * 60 * 1000)); // 1 hour
-    document.cookie = `showRecentGames=${show}; expires=${expires.toUTCString()}; path=/`;
-    setShowRecentGames(show);
-  };
-
-
 
   // Load tracked games from localStorage or API
   const loadTrackedGames = useCallback(async () => {
@@ -303,7 +317,7 @@ function DashboardInner() {
   const searchGames = useCallback(async (e?: React.FormEvent) => {
     if (e) e.preventDefault();
     if (!searchQuery.trim()) {
-      setRecentGamesCookie(false);
+      setRecentGamesVisible(false);
       updateURL(); // Clear URL parameters
       loadRecentGames();
       return;
@@ -331,7 +345,7 @@ function DashboardInner() {
       if (signal.aborted) return;
       setGames(data);
       setShowRefine(true);
-      setRecentGamesCookie(true);
+      setRecentGamesVisible(true);
     } catch (err) {
       if ((err as { name?: string })?.name === 'AbortError') return;
       setError(err instanceof Error ? err.message : 'Failed to search games');
@@ -339,30 +353,11 @@ function DashboardInner() {
     } finally {
       if (!signal.aborted) setLoading(false);
     }
-  }, [searchQuery, siteFilter, refineText, loadRecentGames, updateURL, getFetchSignal]);
+  }, [searchQuery, siteFilter, refineText, loadRecentGames, updateURL, getFetchSignal, setRecentGamesVisible]);
 
-  // Load recent games on mount and check cookie/user preference for visibility
   useEffect(() => {
-    const recentGamesVisible = document.cookie
-      .split('; ')
-      .find(row => row.startsWith('showRecentGames='))
-      ?.split('=')[1] === 'true';
-    
-    setShowRecentGames(recentGamesVisible);
-    loadRecentGames(); // Always load games, but visibility is controlled by state
-    
-    // Fetch user preference for always showing recent uploads
-    if (status === 'authenticated') {
-      fetch('/api/user/me')
-        .then(res => res.ok ? res.json() : null)
-        .then(data => {
-          if (data?.preferences?.homepage?.showRecentUploads) {
-            setShowRecentGames(true);
-          }
-        })
-        .catch(() => {}); // Silently ignore errors
-    }
-  }, [loadRecentGames, status]);
+    loadRecentGames();
+  }, [loadRecentGames]);
 
   // Load tracked games when authentication status changes
   useEffect(() => {
@@ -623,6 +618,17 @@ function DashboardInner() {
             </div>
           )}
         </form>
+        <PageLayoutSettings
+          variant="homepage"
+          layoutMode={layoutMode}
+          setLayoutMode={setLayoutMode}
+          customCols={customCols}
+          setCustomCols={setCustomCols}
+          customRows={customRows}
+          setCustomRows={setCustomRows}
+          showLayoutDropdown={showLayoutDropdown}
+          setShowLayoutDropdown={setShowLayoutDropdown}
+        />
         {/* Site Filter */}
         <div className="mb-4 sm:mb-6">
           <div className="flex items-center justify-between mb-2">
@@ -771,7 +777,7 @@ function DashboardInner() {
         {!showRecentGames && games.length > 0 && searchQuery === '' && (
           <div className="text-center mb-6">
             <button
-              onClick={() => setRecentGamesCookie(true)}
+              onClick={() => setRecentGamesVisible(true)}
               className="px-6 py-3 bg-gradient-to-r from-blue-500 to-cyan-500 text-white rounded-lg hover:from-blue-600 hover:to-cyan-600 transition-all duration-200 font-medium shadow-lg hover:shadow-xl transform hover:scale-105"
             >
               Show Recent Uploads
@@ -780,6 +786,16 @@ function DashboardInner() {
         )}
 
         {/* Mobile-optimized Games Grid */}
+        {layoutMode === 'horizontal' && (showRecentGames || searchQuery !== '') && displayGames.length > 0 && (
+          <div className="mb-4 text-center">
+            <div className="inline-flex items-center gap-2 px-4 py-2 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-700 rounded-lg text-sm text-blue-700 dark:text-blue-300">
+              <span>⬅️</span>
+              <span>Scroll horizontally to browse games</span>
+              <span>➡️</span>
+            </div>
+          </div>
+        )}
+
         {(showRecentGames || searchQuery !== '') && (() => {
           // Spinner is purely tied to the in-flight fetch. Enrichment (IGDB
           // images + Steam AppID resolution) runs in the background on the
@@ -789,7 +805,10 @@ function DashboardInner() {
           // navigates or clicks Refresh.
           const showSpinner = loading;
           return (
-          <div className="grid grid-cols-2 md:grid-cols-5 gap-4 sm:gap-6">
+          <div
+            className={defaultGridClass}
+            style={layoutMode === 'grid' ? customGridStyle : undefined}
+          >
             {showSpinner ? (
               <div className="col-span-full flex flex-col items-center justify-center py-12 space-y-4">
                 <div className="relative">
@@ -842,7 +861,7 @@ function DashboardInner() {
                       onTrack={status === 'authenticated' && !trackState.isExactTracked ? () => handleTrackGame(game) : undefined}
                       onUntrack={status === 'authenticated' && trackState.isExactTracked ? () => handleUntrackGame(game) : undefined}
                       trackButtonText={trackState.hasTrackedVariant ? '↻ Track This Version' : '➕ Track Game'}
-                      className=""
+                      className={layoutMode === 'horizontal' ? 'min-w-[160px] snap-start shrink-0' : ''}
                     />
                   );
                 })

--- a/src/app/tracking/page.tsx
+++ b/src/app/tracking/page.tsx
@@ -11,6 +11,9 @@ import { useConfirm } from '../../contexts/ConfirmContext';
 import { cleanGameTitle } from '../../utils/steamApi';
 
 import { useNotification } from '../../contexts/NotificationContext';
+import { PageLayoutSettings } from '../../components/PageLayoutSettings';
+import { usePersistedLayoutPreferences } from '../../hooks/usePersistedPagePreferences';
+import { buildCustomGridStyle } from '../../utils/pagePreferences';
 
 
 
@@ -114,57 +117,18 @@ export default function TrackingDashboard() {
   // Advanced view for showing original titles
   const [showAdvanced, setShowAdvanced] = useState(false);
   
-  // Helper function to get cookie value
-  const getCookie = (name: string): string | null => {
-    if (typeof document === 'undefined') return null;
-    const value = document.cookie
-      .split('; ')
-      .find(row => row.startsWith(`${name}=`))
-      ?.split('=')[1];
-    return value || null;
-  };
-  
-  // Helper function to set cookie
-  const setCookie = (name: string, value: string, days: number = 365) => {
-    if (typeof document === 'undefined') return;
-    const expires = new Date();
-    expires.setTime(expires.getTime() + days * 24 * 60 * 60 * 1000);
-    document.cookie = `${name}=${value};expires=${expires.toUTCString()};path=/`;
-  };
-  
-  // Layout mode: 'grid' (responsive), 'horizontal' (1 row)
-  const [layoutMode, setLayoutMode] = useState<'grid' | 'horizontal'>(() => {
-    const saved = getCookie('trackingLayoutMode');
-    if (saved === 'grid' || saved === 'horizontal') {
-      return saved;
-    }
-    return 'grid';
-  });
-  
-  // Layout customization state
-  const [customCols, setCustomCols] = useState<number | 'auto'>(() => {
-    const saved = getCookie('trackingCustomCols');
-    if (saved === 'auto') return 'auto';
-    if (saved && !isNaN(Number(saved))) return Number(saved);
-    return 'auto';
-  });
-  const [customRows, setCustomRows] = useState<number | 'auto'>(() => {
-    const saved = getCookie('trackingCustomRows');
-    if (saved === 'auto') return 'auto';
-    if (saved && !isNaN(Number(saved))) return Number(saved);
-    return 'auto';
-  });
+  const {
+    layoutMode,
+    setLayoutMode,
+    customCols,
+    setCustomCols,
+    customRows,
+    setCustomRows,
+    showLayoutDropdown,
+    setShowLayoutDropdown,
+  } = usePersistedLayoutPreferences('tracking', status === 'authenticated');
 
-  // Dropdown state for mobile layout settings
-  const [showLayoutDropdown, setShowLayoutDropdown] = useState(false);
-
-  // Compute grid style for custom layout
-  const customGridStyle = layoutMode === 'grid' ? {
-    display: 'grid',
-    gridTemplateColumns: customCols === 'auto' ? undefined : `repeat(${customCols}, minmax(0, 1fr))`,
-    gridTemplateRows: customRows === 'auto' ? undefined : `repeat(${customRows}, minmax(0, 1fr))`,
-    gap: '1rem',
-  } : undefined;
+  const customGridStyle = buildCustomGridStyle(layoutMode, customCols, customRows);
   
   // Title migration state
   const [migrationStatus, setMigrationStatus] = useState<{
@@ -669,16 +633,6 @@ export default function TrackingDashboard() {
     }
   }, [status, loadTrackedGames]);
 
-  // Save layout and custom grid preferences to cookies
-  useEffect(() => {
-    setCookie('trackingLayoutMode', layoutMode);
-  }, [layoutMode]);
-
-  useEffect(() => {
-    setCookie('trackingCustomCols', customCols === 'auto' ? 'auto' : String(customCols));
-    setCookie('trackingCustomRows', customRows === 'auto' ? 'auto' : String(customRows));
-  }, [customCols, customRows]);
-
   const handleUntrack = async (gameId: string) => {
     try {
       const response = await fetch(`/api/tracking?gameId=${gameId}`, {
@@ -881,34 +835,16 @@ export default function TrackingDashboard() {
                         <span className="text-lg font-bold text-gradient">{trackedGames.length} games</span>
                       </div>
 
-                      {/* Layout Controls */}
-                      <div className="flex items-center gap-2 card-gradient backdrop-blur-sm border border-white/20 dark:border-white/10 px-3 py-2 rounded-xl shadow-lg">
-                        <span className="text-xs font-medium text-slate-500 dark:text-slate-400">Layout:</span>
-                        <div className="flex gap-1">
-                          <button
-                            onClick={() => setLayoutMode('grid')}
-                            className={`p-2 rounded-lg transition-all duration-200 text-lg ${
-                              layoutMode === 'grid'
-                                ? 'bg-primary-500 text-white shadow-md transform scale-105'
-                                : 'hover:bg-white/50 dark:hover:bg-gray-700/50 text-slate-600 dark:text-slate-400'
-                            }`}
-                            title="Grid View"
-                          >
-                            🔲
-                          </button>
-                          <button
-                            onClick={() => setLayoutMode('horizontal')}
-                            className={`p-2 rounded-lg transition-all duration-200 text-lg ${
-                              layoutMode === 'horizontal'
-                                ? 'bg-primary-500 text-white shadow-md transform scale-105'
-                                : 'hover:bg-white/50 dark:hover:bg-gray-700/50 text-slate-600 dark:text-slate-400'
-                            }`}
-                            title="Horizontal Scroll"
-                          >
-                            ⬅️➡️
-                          </button>
-                        </div>
-                      </div>
+                      <PageLayoutSettings
+                        layoutMode={layoutMode}
+                        setLayoutMode={setLayoutMode}
+                        customCols={customCols}
+                        setCustomCols={setCustomCols}
+                        customRows={customRows}
+                        setCustomRows={setCustomRows}
+                        showLayoutDropdown={showLayoutDropdown}
+                        setShowLayoutDropdown={setShowLayoutDropdown}
+                      />
                     </div>
 
                     {/* Right: Advanced Toggle */}
@@ -1015,108 +951,6 @@ export default function TrackingDashboard() {
                   </div>
                 </div>
               </div>
-
-              {/* Mobile Layout Dropdown - Rendered outside container with backdrop */}
-              {showLayoutDropdown && (
-                <>
-                  {/* Backdrop */}
-                  <div 
-                    className="sm:hidden fixed inset-0 bg-black/50 z-[9998] backdrop-blur-sm"
-                    onClick={() => setShowLayoutDropdown(false)}
-                  />
-                  {/* Dropdown */}
-                  <div className="sm:hidden fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-[9999] bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl shadow-2xl p-4 w-[90vw] max-w-sm max-h-[80vh] overflow-y-auto">
-                    <div className="flex flex-col gap-3">
-                      {/* Close button */}
-                      <div className="flex items-center justify-between mb-2">
-                        <h3 className="text-sm font-semibold text-slate-700 dark:text-slate-300">Layout Settings</h3>
-                        <button
-                          onClick={() => setShowLayoutDropdown(false)}
-                          className="p-1 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition-colors"
-                        >
-                          <span className="text-lg">✕</span>
-                        </button>
-                      </div>
-                      {/* Layout Mode Buttons */}
-                      <div>
-                        <label className="text-xs font-medium text-slate-600 dark:text-slate-400 mb-2 block">Layout Mode:</label>
-                        <div className="flex gap-2">
-                              <button
-                                onClick={() => {
-                                  setLayoutMode('grid');
-                                  setShowLayoutDropdown(false);
-                                }}
-                                className={`flex-1 p-2 rounded-lg text-lg ${
-                                  layoutMode === 'grid'
-                                    ? 'bg-primary-500 text-white shadow-md'
-                                    : 'bg-gray-100 dark:bg-gray-800 text-slate-600 dark:text-slate-400'
-                                }`}
-                                title="Grid View"
-                              >
-                                🔲
-                              </button>
-                              <button
-                                onClick={() => {
-                                  setLayoutMode('horizontal');
-                                  setShowLayoutDropdown(false);
-                                }}
-                                className={`flex-1 p-2 rounded-lg text-lg ${
-                                  layoutMode === 'horizontal'
-                                    ? 'bg-primary-500 text-white shadow-md'
-                                    : 'bg-gray-100 dark:bg-gray-800 text-slate-600 dark:text-slate-400'
-                                }`}
-                                title="Horizontal Scroll"
-                              >
-                                ⬅️➡️
-                              </button>
-                            </div>
-                          </div>
-                          {/* Grid Customization - Always show for mobile when grid mode is active */}
-                          {layoutMode === 'grid' && (
-                            <div className="pt-3 border-t border-gray-200 dark:border-gray-700">
-                              <label className="text-xs font-medium text-slate-600 dark:text-slate-400 mb-2 block">🎛️ Grid Size:</label>
-                              <div className="flex flex-col gap-2">
-                                <div className="flex items-center gap-2">
-                                  <label className="text-xs text-slate-500 dark:text-slate-400 w-16">Columns:</label>
-                                  <input
-                                    type="number"
-                                    min={1}
-                                    max={12}
-                                    value={customCols === 'auto' ? '' : customCols}
-                                    onChange={e => setCustomCols(e.target.value === '' ? 'auto' : Math.max(1, Math.min(12, Number(e.target.value))))}
-                                    className="flex-1 px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-700 text-sm bg-white dark:bg-gray-900 focus:ring-2 focus:ring-primary-500 focus:border-transparent"
-                                    placeholder="auto"
-                                  />
-                                  <button
-                                    type="button"
-                                    className={`px-3 py-2 rounded-lg text-xs font-medium transition-all ${customCols === 'auto' ? 'bg-primary-500 text-white shadow-md' : 'bg-gray-200 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-300 dark:hover:bg-gray-700'}`}
-                                    onClick={() => setCustomCols('auto')}
-                                  >Auto</button>
-                                </div>
-                                <div className="flex items-center gap-2">
-                                  <label className="text-xs text-slate-500 dark:text-slate-400 w-16">Rows:</label>
-                                  <input
-                                    type="number"
-                                    min={1}
-                                    max={12}
-                                    value={customRows === 'auto' ? '' : customRows}
-                                    onChange={e => setCustomRows(e.target.value === '' ? 'auto' : Math.max(1, Math.min(12, Number(e.target.value))))}
-                                    className="flex-1 px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-700 text-sm bg-white dark:bg-gray-900 focus:ring-2 focus:ring-primary-500 focus:border-transparent"
-                                    placeholder="auto"
-                                  />
-                                  <button
-                                    type="button"
-                                    className={`px-3 py-2 rounded-lg text-xs font-medium transition-all ${customRows === 'auto' ? 'bg-primary-500 text-white shadow-md' : 'bg-gray-200 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-300 dark:hover:bg-gray-700'}`}
-                                    onClick={() => setCustomRows('auto')}
-                                  >Auto</button>
-                                </div>
-                              </div>
-                            </div>
-                          )}
-                        </div>
-                      </div>
-                  </>
-                )}
 
               {/* Grid customization - Desktop only, show below when in advanced mode */}
               {showAdvanced && layoutMode === 'grid' && (

--- a/src/components/GameDownloadLinks.tsx
+++ b/src/components/GameDownloadLinks.tsx
@@ -19,6 +19,13 @@ interface DownloadContext {
   source?: string;
 }
 
+type DownloadLinksApiResponse = {
+  downloadLinks?: DownloadLink[];
+  context?: DownloadContext;
+  notice?: string;
+  noticeType?: string;
+};
+
 interface GameDownloadLinksProps {
   // For tracked games
   gameId?: string;
@@ -26,6 +33,8 @@ interface GameDownloadLinksProps {
   // For any game from main dashboard
   postId?: string;
   siteType?: string;
+  /** Original post URL (required for DODI follow-post notice). */
+  postUrl?: string;
   // Embedded download links (e.g. from goggames where links are in the initial response)
   embeddedDownloadLinks?: Array<{ url: string; label?: string; service?: string }>;
   gameTitle?: string;
@@ -37,6 +46,7 @@ export function GameDownloadLinks({
   updateIndex, 
   postId, 
   siteType, 
+  postUrl,
   embeddedDownloadLinks,
   gameTitle,
   className = '' 
@@ -44,6 +54,8 @@ export function GameDownloadLinks({
   const [downloadLinks, setDownloadLinks] = useState<DownloadLink[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
+  const [notice, setNotice] = useState('');
+  const [noticeType, setNoticeType] = useState('');
   const [isOpen, setIsOpen] = useState(false);
   const [dropdownPosition, setDropdownPosition] = useState({ top: 0, left: 0, width: 0 });
   const buttonRef = useRef<HTMLButtonElement>(null);
@@ -69,6 +81,8 @@ export function GameDownloadLinks({
 
     setLoading(true);
     setError('');
+    setNotice('');
+    setNoticeType('');
 
     try {
       let url: string;
@@ -81,7 +95,8 @@ export function GameDownloadLinks({
         const params = new URLSearchParams({
           postId,
           siteType,
-          ...(gameTitle && { title: gameTitle })
+          ...(gameTitle && { title: gameTitle }),
+          ...(postUrl && { postUrl }),
         });
         url = `/api/games/links?${params}`;
       } else {
@@ -97,10 +112,17 @@ export function GameDownloadLinks({
         throw new Error('Failed to fetch download links');
       }
 
-      const data = await response.json();
+      const data = (await response.json()) as DownloadLinksApiResponse;
       const links: DownloadLink[] = data.downloadLinks || [];
       const ctx: DownloadContext = data.context || { gameTitle: '', currentVersion: '', type: '' };
       setContext(ctx);
+      setNotice(data.notice || '');
+      setNoticeType(data.noticeType || '');
+
+      if (data.noticeType === 'follow_post') {
+        setDownloadLinks([]);
+        return;
+      }
 
       // If scraper returned nothing, auto-retry a couple of times — the first
       // attempt often fails when FlareSolverr / upstream is cold.
@@ -311,7 +333,25 @@ export function GameDownloadLinks({
               </div>
             )}
 
-            {!loading && !error && downloadLinks.length === 0 && (
+            {!loading && !error && noticeType === 'follow_post' && (
+              <div className="py-2 space-y-3">
+                <p className="text-sm text-amber-800 dark:text-amber-200 bg-amber-50 dark:bg-amber-900/30 border border-amber-200 dark:border-amber-700 rounded-lg p-3">
+                  {notice}
+                </p>
+                {(context.postUrl || postUrl) && (
+                  <a
+                    href={context.postUrl || postUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="block w-full text-center px-4 py-2 bg-purple-600 hover:bg-purple-700 text-white text-sm rounded-lg transition-colors min-h-[40px]"
+                  >
+                    Open post on DODI-Repacks
+                  </a>
+                )}
+              </div>
+            )}
+
+            {!loading && !error && noticeType !== 'follow_post' && downloadLinks.length === 0 && (
               <div className="py-2">
                 <div className="text-gray-500 dark:text-gray-400 text-sm mb-2">
                   No download links available

--- a/src/components/GamePosterCard.tsx
+++ b/src/components/GamePosterCard.tsx
@@ -138,6 +138,7 @@ export function GamePosterCard({
                 <GameDownloadLinks 
                   postId={postId}
                   siteType={siteType}
+                  postUrl={sourceLink || link}
                   embeddedDownloadLinks={embeddedDownloadLinks}
                   gameTitle={title}
                   className="w-full"

--- a/src/components/PageLayoutSettings.tsx
+++ b/src/components/PageLayoutSettings.tsx
@@ -1,0 +1,342 @@
+'use client';
+
+import { useState, type ReactNode } from 'react';
+import type { GridSize, LayoutMode } from '../utils/pagePreferences';
+
+export interface PageLayoutSettingsProps {
+  layoutMode: LayoutMode;
+  setLayoutMode: (mode: LayoutMode) => void;
+  customCols: GridSize;
+  setCustomCols: (value: GridSize) => void;
+  customRows: GridSize;
+  setCustomRows: (value: GridSize) => void;
+  showLayoutDropdown: boolean;
+  setShowLayoutDropdown: (open: boolean) => void;
+  variant?: 'tracking' | 'homepage';
+  className?: string;
+}
+
+function LayoutModeButtons({
+  layoutMode,
+  setLayoutMode,
+  onSelect,
+  activeClass,
+  inactiveClass,
+}: {
+  layoutMode: LayoutMode;
+  setLayoutMode: (mode: LayoutMode) => void;
+  onSelect?: () => void;
+  activeClass: string;
+  inactiveClass: string;
+}) {
+  const pick = (mode: LayoutMode) => {
+    setLayoutMode(mode);
+    onSelect?.();
+  };
+
+  return (
+    <div className="flex gap-1">
+      <button
+        type="button"
+        onClick={() => pick('grid')}
+        className={`p-2 rounded-lg transition-all duration-200 text-lg ${
+          layoutMode === 'grid' ? activeClass : inactiveClass
+        }`}
+        title="Grid view"
+      >
+        🔲
+      </button>
+      <button
+        type="button"
+        onClick={() => pick('horizontal')}
+        className={`p-2 rounded-lg transition-all duration-200 text-lg ${
+          layoutMode === 'horizontal' ? activeClass : inactiveClass
+        }`}
+        title="Horizontal scroll"
+      >
+        ⬅️➡️
+      </button>
+    </div>
+  );
+}
+
+function GridSizeControls({
+  customCols,
+  setCustomCols,
+  customRows,
+  setCustomRows,
+}: {
+  customCols: GridSize;
+  setCustomCols: (value: GridSize) => void;
+  customRows: GridSize;
+  setCustomRows: (value: GridSize) => void;
+}) {
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center gap-2">
+        <label className="text-xs text-slate-500 dark:text-slate-400 w-16 shrink-0">Columns:</label>
+        <input
+          type="number"
+          min={1}
+          max={12}
+          value={customCols === 'auto' ? '' : customCols}
+          onChange={e =>
+            setCustomCols(
+              e.target.value === '' ? 'auto' : Math.max(1, Math.min(12, Number(e.target.value)))
+            )
+          }
+          className="flex-1 min-w-0 px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-700 text-sm bg-white dark:bg-gray-900 focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+          placeholder="auto"
+        />
+        <button
+          type="button"
+          className={`px-3 py-2 rounded-lg text-xs font-medium transition-all shrink-0 ${
+            customCols === 'auto'
+              ? 'bg-primary-500 text-white shadow-md'
+              : 'bg-gray-200 dark:bg-gray-800 text-gray-700 dark:text-gray-300'
+          }`}
+          onClick={() => setCustomCols('auto')}
+        >
+          Auto
+        </button>
+      </div>
+      <div className="flex items-center gap-2">
+        <label className="text-xs text-slate-500 dark:text-slate-400 w-16 shrink-0">Rows:</label>
+        <input
+          type="number"
+          min={1}
+          max={12}
+          value={customRows === 'auto' ? '' : customRows}
+          onChange={e =>
+            setCustomRows(
+              e.target.value === '' ? 'auto' : Math.max(1, Math.min(12, Number(e.target.value)))
+            )
+          }
+          className="flex-1 min-w-0 px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-700 text-sm bg-white dark:bg-gray-900 focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+          placeholder="auto"
+        />
+        <button
+          type="button"
+          className={`px-3 py-2 rounded-lg text-xs font-medium transition-all shrink-0 ${
+            customRows === 'auto'
+              ? 'bg-primary-500 text-white shadow-md'
+              : 'bg-gray-200 dark:bg-gray-800 text-gray-700 dark:text-gray-300'
+          }`}
+          onClick={() => setCustomRows('auto')}
+        >
+          Auto
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function LayoutSettingsModal({
+  open,
+  onClose,
+  title,
+  layoutMode,
+  modeButtons,
+  gridControls,
+}: {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  layoutMode: LayoutMode;
+  modeButtons: ReactNode;
+  gridControls: ReactNode;
+}) {
+  if (!open) return null;
+
+  return (
+    <>
+      <div
+        className="sm:hidden fixed inset-0 bg-black/50 z-[9998] backdrop-blur-sm"
+        onClick={onClose}
+      />
+      <div className="sm:hidden fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-[9999] bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl shadow-2xl p-4 w-[90vw] max-w-sm max-h-[80vh] overflow-y-auto">
+        <div className="flex items-center justify-between mb-3">
+          <h3 className="text-sm font-semibold text-gray-800 dark:text-gray-200">{title}</h3>
+          <button type="button" onClick={onClose} className="p-1 text-lg" aria-label="Close">
+            ✕
+          </button>
+        </div>
+        <label className="text-xs font-medium text-gray-600 dark:text-slate-400 mb-2 block">Mode</label>
+        <div className="flex gap-2">{modeButtons}</div>
+        {layoutMode === 'grid' && (
+          <div className="mt-3 pt-3 border-t border-gray-200 dark:border-gray-700">
+            <label className="text-xs font-medium text-gray-600 dark:text-slate-400 mb-2 block">
+              Grid size
+            </label>
+            {gridControls}
+          </div>
+        )}
+      </div>
+    </>
+  );
+}
+
+export function PageLayoutSettings({
+  layoutMode,
+  setLayoutMode,
+  customCols,
+  setCustomCols,
+  customRows,
+  setCustomRows,
+  showLayoutDropdown,
+  setShowLayoutDropdown,
+  variant = 'tracking',
+  className = '',
+}: PageLayoutSettingsProps) {
+  const isHomepage = variant === 'homepage';
+  const closeDropdown = () => setShowLayoutDropdown(false);
+
+  const activeClass = isHomepage
+    ? 'bg-blue-600 text-white shadow-md'
+    : 'bg-primary-500 text-white shadow-md transform scale-105';
+  const inactiveClass = isHomepage
+    ? 'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400'
+    : 'hover:bg-white/50 dark:hover:bg-gray-700/50 text-slate-600 dark:text-slate-400';
+
+  const modeButtons = (
+    <LayoutModeButtons
+      layoutMode={layoutMode}
+      setLayoutMode={setLayoutMode}
+      onSelect={closeDropdown}
+      activeClass={activeClass}
+      inactiveClass={inactiveClass}
+    />
+  );
+
+  const gridControls = (
+    <GridSizeControls
+      customCols={customCols}
+      setCustomCols={setCustomCols}
+      customRows={customRows}
+      setCustomRows={setCustomRows}
+    />
+  );
+
+  const modal = (
+    <LayoutSettingsModal
+      open={showLayoutDropdown}
+      onClose={closeDropdown}
+      title={isHomepage ? 'Layout' : 'Layout settings'}
+      layoutMode={layoutMode}
+      modeButtons={modeButtons}
+      gridControls={gridControls}
+    />
+  );
+
+  if (isHomepage) {
+    return (
+      <HomepageLayoutPanel
+        className={className}
+        layoutMode={layoutMode}
+        modeButtons={modeButtons}
+        gridControls={gridControls}
+        modal={modal}
+        showLayoutDropdown={showLayoutDropdown}
+        setShowLayoutDropdown={setShowLayoutDropdown}
+      />
+    );
+  }
+
+  return (
+    <>
+      <div
+        className={`hidden sm:flex items-center gap-2 card-gradient backdrop-blur-sm border border-white/20 dark:border-white/10 px-3 py-2 rounded-xl shadow-lg ${className}`}
+      >
+        <span className="text-xs font-medium text-slate-500 dark:text-slate-400">Layout:</span>
+        {modeButtons}
+      </div>
+      <div className="sm:hidden ml-auto relative">
+        <button
+          type="button"
+          className="px-3 py-2 rounded-lg bg-gradient-to-r from-blue-500 to-cyan-500 text-white text-xs font-medium shadow"
+          onClick={() => setShowLayoutDropdown(!showLayoutDropdown)}
+        >
+          ⚙️ Layout
+        </button>
+      </div>
+      {modal}
+    </>
+  );
+}
+
+function HomepageMobileLayoutToggle({
+  showLayoutDropdown,
+  setShowLayoutDropdown,
+}: {
+  showLayoutDropdown: boolean;
+  setShowLayoutDropdown: (open: boolean) => void;
+}) {
+  return (
+    <div className="sm:hidden flex justify-end mb-3">
+      <button
+        type="button"
+        className="px-3 py-2 rounded-lg bg-blue-600 text-white text-xs font-medium shadow"
+        onClick={() => setShowLayoutDropdown(!showLayoutDropdown)}
+      >
+        ⚙️ Layout
+      </button>
+    </div>
+  );
+}
+
+function HomepageLayoutPanel({
+  className,
+  layoutMode,
+  modeButtons,
+  gridControls,
+  modal,
+  showLayoutDropdown,
+  setShowLayoutDropdown,
+}: {
+  className: string;
+  layoutMode: LayoutMode;
+  modeButtons: ReactNode;
+  gridControls: ReactNode;
+  modal: ReactNode;
+  showLayoutDropdown: boolean;
+  setShowLayoutDropdown: (open: boolean) => void;
+}) {
+  const [desktopPanelOpen, setDesktopPanelOpen] = useState(false);
+
+  return (
+    <div className={className}>
+      <div className="hidden sm:flex justify-end mb-3">
+        <button
+          type="button"
+          onClick={() => setDesktopPanelOpen(prev => !prev)}
+          className={`px-4 py-2 rounded-lg text-sm font-medium shadow transition-all duration-200 flex items-center gap-2 ${
+            desktopPanelOpen
+              ? 'bg-blue-600 text-white'
+              : 'bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 border border-gray-200 dark:border-gray-700 hover:bg-gray-200 dark:hover:bg-gray-700'
+          }`}
+          title={desktopPanelOpen ? 'Hide layout options' : 'Show layout options'}
+        >
+          <span>⚙️</span>
+          <span>{desktopPanelOpen ? 'Hide Layout Options' : 'Edit Layout'}</span>
+        </button>
+      </div>
+      {desktopPanelOpen && (
+        <div className="hidden sm:flex flex-wrap items-center gap-3 mb-4 p-3 bg-gray-50 dark:bg-gray-800/50 border border-gray-200 dark:border-gray-700 rounded-lg">
+          <span className="text-xs font-medium text-gray-600 dark:text-gray-400">Layout:</span>
+          {modeButtons}
+          {layoutMode === 'grid' && (
+            <div className="flex flex-wrap items-center gap-3 flex-1 min-w-[200px] border-l border-gray-200 dark:border-gray-600 pl-3">
+              <span className="text-xs font-medium text-gray-500 dark:text-gray-400">Grid:</span>
+              <div className="flex flex-wrap gap-3 flex-1">{gridControls}</div>
+            </div>
+          )}
+        </div>
+      )}
+      <HomepageMobileLayoutToggle
+        showLayoutDropdown={showLayoutDropdown}
+        setShowLayoutDropdown={setShowLayoutDropdown}
+      />
+      {modal}
+    </div>
+  );
+}

--- a/src/hooks/usePersistedPagePreferences.ts
+++ b/src/hooks/usePersistedPagePreferences.ts
@@ -1,0 +1,229 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  type GridSize,
+  type HomepagePreferences,
+  type LayoutMode,
+  type LayoutPreferences,
+  homepageFromDbRecord,
+  layoutFromDbRecord,
+  readHomepageFromCookies,
+  readLayoutFromCookies,
+  writeHomepageToCookies,
+  writeLayoutToCookies,
+} from '../utils/pagePreferences';
+
+const SAVE_DEBOUNCE_MS = 800;
+
+async function patchUserPreferences(payload: Record<string, unknown>): Promise<void> {
+  const res = await fetch('/api/user/preferences', {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) {
+    console.warn('[preferences] Failed to save:', await res.text().catch(() => res.statusText));
+  }
+}
+
+function layoutPayload(prefs: LayoutPreferences) {
+  return {
+    layoutMode: prefs.layoutMode,
+    customCols: prefs.customCols === 'auto' ? 'auto' : prefs.customCols,
+    customRows: prefs.customRows === 'auto' ? 'auto' : prefs.customRows,
+  };
+}
+
+export function usePersistedLayoutPreferences(page: 'tracking', authenticated: boolean) {
+  const initial = readLayoutFromCookies(page);
+  const [layoutMode, setLayoutMode] = useState<LayoutMode>(initial.layoutMode);
+  const [customCols, setCustomCols] = useState<GridSize>(initial.customCols);
+  const [customRows, setCustomRows] = useState<GridSize>(initial.customRows);
+  const [showLayoutDropdown, setShowLayoutDropdown] = useState(false);
+  const loadedFromDb = useRef(false);
+  const prefsReady = useRef(false);
+  const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const queueDbSave = useCallback(
+    (prefs: LayoutPreferences) => {
+      if (!authenticated) return;
+      if (saveTimer.current) clearTimeout(saveTimer.current);
+      saveTimer.current = setTimeout(() => {
+        void patchUserPreferences({ tracking: layoutPayload(prefs) });
+      }, SAVE_DEBOUNCE_MS);
+    },
+    [authenticated]
+  );
+
+  useEffect(() => {
+    if (!authenticated) {
+      prefsReady.current = true;
+      return;
+    }
+    if (loadedFromDb.current) return;
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const res = await fetch('/api/user/me');
+        if (!res.ok || cancelled) return;
+        const data = await res.json();
+        const dbPrefs = layoutFromDbRecord(data.preferences?.tracking);
+        if (dbPrefs && !cancelled) {
+          loadedFromDb.current = true;
+          const merged: LayoutPreferences = {
+            layoutMode: dbPrefs.layoutMode ?? initial.layoutMode,
+            customCols: dbPrefs.customCols ?? initial.customCols,
+            customRows: dbPrefs.customRows ?? initial.customRows,
+          };
+          setLayoutMode(merged.layoutMode);
+          setCustomCols(merged.customCols);
+          setCustomRows(merged.customRows);
+          writeLayoutToCookies(page, merged);
+        }
+      } catch {
+        /* non-critical */
+      } finally {
+        if (!cancelled) prefsReady.current = true;
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [authenticated, page]);
+
+  useEffect(() => {
+    if (!prefsReady.current) return;
+    const prefs: LayoutPreferences = { layoutMode, customCols, customRows };
+    writeLayoutToCookies(page, prefs);
+    queueDbSave(prefs);
+  }, [layoutMode, customCols, customRows, page, queueDbSave]);
+
+  return {
+    layoutMode,
+    setLayoutMode,
+    customCols,
+    setCustomCols,
+    customRows,
+    setCustomRows,
+    showLayoutDropdown,
+    setShowLayoutDropdown,
+  };
+}
+
+export function usePersistedHomepagePreferences(authenticated: boolean) {
+  const initial = readHomepageFromCookies();
+  const [layoutMode, setLayoutMode] = useState<LayoutMode>(initial.layoutMode);
+  const [customCols, setCustomCols] = useState<GridSize>(initial.customCols);
+  const [customRows, setCustomRows] = useState<GridSize>(initial.customRows);
+  const [showRecentGames, setShowRecentGames] = useState(initial.showRecentUploads);
+  const [showAllGames, setShowAllGames] = useState(initial.showAllGames);
+  const [showLayoutDropdown, setShowLayoutDropdown] = useState(false);
+  const loadedFromDb = useRef(false);
+  const prefsReady = useRef(false);
+  const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const queueDbSave = useCallback(
+    (prefs: HomepagePreferences) => {
+      if (!authenticated) return;
+      if (saveTimer.current) clearTimeout(saveTimer.current);
+      saveTimer.current = setTimeout(() => {
+        void patchUserPreferences({
+          homepage: {
+            ...layoutPayload(prefs),
+            showRecentUploads: prefs.showRecentUploads,
+            showAllGames: prefs.showAllGames,
+          },
+        });
+      }, SAVE_DEBOUNCE_MS);
+    },
+    [authenticated]
+  );
+
+  const snapshot = useCallback(
+    (): HomepagePreferences => ({
+      layoutMode,
+      customCols,
+      customRows,
+      showRecentUploads: showRecentGames,
+      showAllGames,
+    }),
+    [layoutMode, customCols, customRows, showRecentGames, showAllGames]
+  );
+
+  useEffect(() => {
+    if (!authenticated) {
+      prefsReady.current = true;
+      return;
+    }
+    if (loadedFromDb.current) return;
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const res = await fetch('/api/user/me');
+        if (!res.ok || cancelled) return;
+        const data = await res.json();
+        const dbPrefs = homepageFromDbRecord(data.preferences?.homepage);
+        if (dbPrefs && !cancelled) {
+          loadedFromDb.current = true;
+          const merged: HomepagePreferences = {
+            layoutMode: dbPrefs.layoutMode ?? initial.layoutMode,
+            customCols: dbPrefs.customCols ?? initial.customCols,
+            customRows: dbPrefs.customRows ?? initial.customRows,
+            showRecentUploads: dbPrefs.showRecentUploads ?? initial.showRecentUploads,
+            showAllGames: dbPrefs.showAllGames ?? initial.showAllGames,
+          };
+          setLayoutMode(merged.layoutMode);
+          setCustomCols(merged.customCols);
+          setCustomRows(merged.customRows);
+          setShowRecentGames(merged.showRecentUploads);
+          setShowAllGames(merged.showAllGames);
+          writeHomepageToCookies(merged);
+        }
+      } catch {
+        /* non-critical */
+      } finally {
+        if (!cancelled) prefsReady.current = true;
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [authenticated]);
+
+  useEffect(() => {
+    if (!prefsReady.current) return;
+    const prefs = snapshot();
+    writeHomepageToCookies(prefs);
+    queueDbSave(prefs);
+  }, [snapshot, queueDbSave]);
+
+  const setRecentGamesVisible = useCallback((show: boolean) => {
+    setShowRecentGames(show);
+  }, []);
+
+  const setShowAllGamesPersisted = useCallback((value: boolean | ((prev: boolean) => boolean)) => {
+    setShowAllGames(value);
+  }, []);
+
+  return {
+    layoutMode,
+    setLayoutMode,
+    customCols,
+    setCustomCols,
+    customRows,
+    setCustomRows,
+    showLayoutDropdown,
+    setShowLayoutDropdown,
+    showRecentGames,
+    setRecentGamesVisible,
+    showAllGames,
+    setShowAllGames: setShowAllGamesPersisted,
+  };
+}

--- a/src/lib/downloadSitePolicy.ts
+++ b/src/lib/downloadSitePolicy.ts
@@ -1,0 +1,51 @@
+/** Shown when users request download links for DODI-Repacks tracked games. */
+export const DODI_FOLLOW_POST_NOTICE =
+  'DODI-Repacks downloads are not listed here. Open the original post on DODI-Repacks to get magnet links and installers.';
+
+export function isDodiSiteType(siteType: string | null | undefined): boolean {
+  return (siteType || '').trim().toLowerCase() === 'dodi';
+}
+
+export function resolveTrackedGameSiteType(game: {
+  gameId?: string;
+  source?: string;
+  gameLink?: string;
+}): string | null {
+  if (game.gameId) {
+    const m = String(game.gameId).match(/^([a-z]+)_/i);
+    if (m) return m[1].toLowerCase();
+  }
+  const link = (game.gameLink || '').toLowerCase();
+  if (link.includes('dodi-repacks')) return 'dodi';
+  const src = (game.source || '').toLowerCase();
+  if (src.includes('dodi')) return 'dodi';
+  return null;
+}
+
+export function isDodiTrackedGame(game: {
+  gameId?: string;
+  source?: string;
+  gameLink?: string;
+}): boolean {
+  return isDodiSiteType(resolveTrackedGameSiteType(game));
+}
+
+export function buildDodiFollowPostDownloadResponse(game: {
+  title?: string;
+  gameLink?: string;
+  lastKnownVersion?: string;
+}) {
+  return {
+    downloadLinks: [] as [],
+    totalLinks: 0,
+    notice: DODI_FOLLOW_POST_NOTICE,
+    noticeType: 'follow_post' as const,
+    context: {
+      gameTitle: game.title || 'Unknown',
+      currentVersion: game.lastKnownVersion || 'Latest',
+      type: 'dodi-follow-post',
+      postUrl: game.gameLink || '',
+      source: 'dodi',
+    },
+  };
+}

--- a/src/lib/gameapi/helpers.js
+++ b/src/lib/gameapi/helpers.js
@@ -391,6 +391,8 @@ export async function getFreshSteamripCookie() {
       body: JSON.stringify({
         cmd: 'request.get',
         url: 'https://steamrip.com/wp-json/wp/v2/posts',
+        session: 'steamrip',
+        maxTimeout: timeoutMs,
         userAgent: 'GameSearch-API-v2/2.0'
       })
     }, attempts, timeoutMs);
@@ -469,7 +471,7 @@ export async function fetchSteamrip(url, isPageRequest = false) {
   try {
     const userAgent = isPageRequest ? 'GameSearch-API-v2-PageFetch/2.0' : 'GameSearch-API-v2/2.0';
 
-    // Try direct fetch first (like skidrow) â€” avoids FlareSolverr delay when CF is not active
+    // Try direct fetch first — avoids FlareSolverr delay when CF is not active
     let response = await siteFetch(url, {
       headers: {
         'User-Agent': userAgent,
@@ -478,15 +480,12 @@ export async function fetchSteamrip(url, isPageRequest = false) {
       }
     });
 
-    // Check for Cloudflare protection â€” even if status is 200
     let isCloudflare = hasCloudflareProtection(response);
-    console.log(`Initial fetch of ${url}: status=${response.status}, CF detected=${isCloudflare}`);
+    console.log(`Initial SteamRip fetch of ${url}: status=${response.status}, CF detected=${isCloudflare}`);
 
-    // If response looks OK but is HTML, check content for CF protection
     if (!isCloudflare && response.ok && response.headers.get('content-type')?.includes('text/html')) {
       const text = await response.text();
       isCloudflare = hasCloudflareProtection(response, text);
-
       if (!isCloudflare) {
         return new Response(text, {
           status: response.status,
@@ -498,54 +497,24 @@ export async function fetchSteamrip(url, isPageRequest = false) {
       return response;
     }
 
-    // Cloudflare protection detected â€” try with cached cookie
     if (isCloudflare) {
-      console.log('Cloudflare protection detected on SteamRip, using FlareSolverr cookie');
-      const cookie = await getValidSteamripCookie();
-
-      const cookieUserAgent = cookie.userAgent || userAgent;
-      const cookieString = cookie.cookies.join('; ');
-
-      response = await siteFetch(url, {
-        headers: {
-          'User-Agent': cookieUserAgent,
-          'Cookie': cookieString,
-          'Accept': 'application/json, text/plain, */*',
-          'Accept-Language': 'en-US,en;q=0.9',
-          'Referer': 'https://steamrip.com/',
-          'Origin': 'https://steamrip.com'
-        }
-      });
-
-      let stillBlocked = hasCloudflareProtection(response);
-      console.log(`After cookie fetch: status=${response.status}, stillBlocked=${stillBlocked}, cookies used=${cookie.cookies.length}`);
-
-      if (!stillBlocked && response.ok && response.headers.get('content-type')?.includes('text/html')) {
-        const text = await response.text();
-        stillBlocked = hasCloudflareProtection(response, text);
-
-        if (!stillBlocked) {
-          return new Response(text, {
-            status: response.status,
-            statusText: response.statusText,
-            headers: response.headers
-          });
-        }
-      } else if (!stillBlocked && response.ok) {
-        return response;
+      console.log('Cloudflare protection detected on SteamRip, trying FlareSolverr direct fetch');
+      const flareResponse = await fetchViaFlaresolverr(url, 'steamrip');
+      if (flareResponse && flareResponse.ok) {
+        return flareResponse;
       }
 
-      // Cached cookie didn't work â€” get a fresh one
-      if (stillBlocked || response.status === 403) {
-        console.log('Cookie did not bypass Cloudflare, getting fresh cookie for SteamRip');
-        const freshCookie = await getFreshSteamripCookie();
-        const freshUserAgent = freshCookie.userAgent || userAgent;
-        const freshCookieString = freshCookie.cookies.join('; ');
+      console.log('FlareSolverr direct fetch failed for SteamRip, falling back to cookie approach');
+      const cookie = await getValidSteamripCookie();
 
-        const retryResponse = await siteFetch(url, {
+      if (cookie.cf_clearance !== 'none' || cookie.cookies.length > 0) {
+        const cookieUserAgent = cookie.userAgent || userAgent;
+        const cookieString = cookie.cookies.join('; ');
+
+        response = await siteFetch(url, {
           headers: {
-            'User-Agent': freshUserAgent,
-            'Cookie': freshCookieString,
+            'User-Agent': cookieUserAgent,
+            'Cookie': cookieString,
             'Accept': 'application/json, text/plain, */*',
             'Accept-Language': 'en-US,en;q=0.9',
             'Referer': 'https://steamrip.com/',
@@ -553,36 +522,77 @@ export async function fetchSteamrip(url, isPageRequest = false) {
           }
         });
 
-        if (!retryResponse.ok) {
-          if (isPageRequest) {
-            console.warn(`Failed to fetch SteamRip page: ${retryResponse.status} ${retryResponse.statusText} (even with fresh cookie)`);
-            return null;
-          } else {
-            throw new Error(`SteamRip API returned ${retryResponse.status}: ${retryResponse.statusText} (even with fresh cookie)`);
+        let stillBlocked = hasCloudflareProtection(response);
+        if (!stillBlocked && response.ok && response.headers.get('content-type')?.includes('text/html')) {
+          const text = await response.text();
+          stillBlocked = hasCloudflareProtection(response, text);
+          if (!stillBlocked) {
+            return new Response(text, {
+              status: response.status,
+              statusText: response.statusText,
+              headers: response.headers
+            });
           }
+        } else if (!stillBlocked && response.ok) {
+          return response;
         }
 
-        return retryResponse;
+        if (stillBlocked || response.status === 403) {
+          console.log('SteamRip cookie stale, refreshing via FlareSolverr');
+          const freshCookie = await getFreshSteamripCookie();
+          const freshUserAgent = freshCookie.userAgent || userAgent;
+          const freshCookieString = freshCookie.cookies.join('; ');
+
+          const retryResponse = await siteFetch(url, {
+            headers: {
+              'User-Agent': freshUserAgent,
+              'Cookie': freshCookieString,
+              'Accept': 'application/json, text/plain, */*',
+              'Accept-Language': 'en-US,en;q=0.9',
+              'Referer': 'https://steamrip.com/',
+              'Origin': 'https://steamrip.com'
+            }
+          });
+
+          let retryBlocked = hasCloudflareProtection(retryResponse);
+          if (!retryBlocked && retryResponse.ok && retryResponse.headers.get('content-type')?.includes('text/html')) {
+            const text = await retryResponse.text();
+            retryBlocked = hasCloudflareProtection(retryResponse, text);
+            if (!retryBlocked) {
+              return new Response(text, {
+                status: retryResponse.status,
+                statusText: retryResponse.statusText,
+                headers: retryResponse.headers
+              });
+            }
+          } else if (!retryBlocked && retryResponse.ok) {
+            return retryResponse;
+          }
+        }
       }
+
+      if (isPageRequest) {
+        console.warn('Failed to fetch SteamRip page (all methods exhausted)');
+        return null;
+      }
+      throw new Error('SteamRip: all fetch methods failed (CF blocking)');
     }
 
     if (!response.ok) {
       if (isPageRequest) {
         console.warn(`Failed to fetch SteamRip page: ${response.status} ${response.statusText}`);
         return null;
-      } else {
-        throw new Error(`SteamRip API returned ${response.status}: ${response.statusText}`);
       }
+      throw new Error(`SteamRip API returned ${response.status}: ${response.statusText}`);
     }
 
     return response;
   } catch (error) {
-    console.error(`Error fetching SteamRip:`, error);
+    console.error('Error fetching SteamRip:', error);
     if (isPageRequest) {
       return null;
-    } else {
-      throw error;
     }
+    throw error;
   }
 }
 
@@ -831,26 +841,46 @@ export async function fetchViaFlaresolverr(url, session = 'default') {
       body = preMatch[1];
     }
 
+    const trimmed = body.trimStart();
+    const contentType =
+      preMatch || trimmed.startsWith('{') || trimmed.startsWith('[')
+        ? 'application/json'
+        : 'text/html';
+
     console.log(`FlareSolverr returned ${body.length} chars, status ${status} for ${url}`);
 
     // Update cookies from the solution while we're at it
-    if (data.solution.cookies?.length && (session === 'skidrowreloaded' || session === 'dodirepacks' || session === 'dodirepacks-fallback')) {
+    if (
+      data.solution.cookies?.length &&
+      (session === 'skidrowreloaded' ||
+        session === 'steamrip' ||
+        session === 'dodirepacks' ||
+        session === 'dodirepacks-fallback')
+    ) {
       const allCookies = data.solution.cookies.map(c => `${c.name}=${c.value}`);
       let cf = null;
       let exp = Date.now() + (4 * 60 * 60 * 1000);
       for (const c of data.solution.cookies) {
         if (c.name === 'cf_clearance') { cf = c.value; if (c.expires) exp = new Date(c.expires * 1000).getTime(); }
       }
+      const jar = {
+        cf_clearance: cf || 'none',
+        cookies: allCookies,
+        userAgent: data.solution.userAgent || null,
+        expires_at: exp,
+      };
       if (session === 'skidrowreloaded') {
-        skidrowCookie = { cf_clearance: cf || 'none', cookies: allCookies, userAgent: data.solution.userAgent || null, expires_at: exp };
+        skidrowCookie = jar;
+      } else if (session === 'steamrip') {
+        steamripCookie = jar;
       } else {
-        dodiCookie = { cf_clearance: cf || 'none', cookies: allCookies, userAgent: data.solution.userAgent || null, expires_at: exp };
+        dodiCookie = jar;
       }
     }
 
     return new Response(body, {
       status,
-      headers: { 'Content-Type': 'application/json' }
+      headers: { 'Content-Type': contentType }
     });
   } catch (error) {
     console.error(`FlareSolverr direct fetch failed for ${url}:`, error.message);
@@ -1280,17 +1310,26 @@ export async function transformPostForV2(post, site, fetchLinks = false) {
 
 // Extract download links for v2
 export async function extractDownloadLinksForV2(postUrl, siteType = 'skidrow', wpContent = null) {
+  // DODI: magnets/hosters live on the post page only — never scrape here.
+  if (siteType === 'dodi') {
+    return [];
+  }
+
   try {
     let html;
     const downloadLinks = [];
 
     if (siteType === 'steamrip') {
       const response = await fetchSteamrip(postUrl, true);
-      if (!response) {
+      if (response && response.ok) {
+        html = await response.text();
+      } else if (wpContent) {
+        console.warn(`SteamRip page fetch failed for ${postUrl}, using WP API content`);
+        html = wpContent;
+      } else {
         console.warn(`Failed to fetch post content from ${postUrl}`);
         return [];
       }
-      html = await response.text();
 
       // Extract all href links from SteamRip
       const hrefRegex = /<a[^>]+href=["']([^"']+)["'][^>]*>([^<]*)<\/a>/gi;
@@ -1467,6 +1506,7 @@ export async function extractDownloadLinksForV2(postUrl, siteType = 'skidrow', w
           }
 
           if (downloadLinks.some(l => l.url === url)) continue;
+          if (isExcludedReloadedSteamUtilityFile(url)) continue;
 
           if (isValidDownloadUrl(url)) {
             const service = extractServiceName(url);
@@ -1650,6 +1690,23 @@ function extractDescription(content) {
   return stripped.length > 300 ? stripped.substring(0, 300) + '...' : stripped;
 }
 
+/**
+ * ReloadedSteam posts often list VC++/DirectX redist archives as separate hoster
+ * buttons (e.g. datanodes.to/.../_CommonRedist.rar) — not the game itself.
+ */
+function isExcludedReloadedSteamUtilityFile(url) {
+  try {
+    const path = decodeURIComponent(new URL(url).pathname);
+    const filename = path.split('/').pop() || path;
+    const lower = filename.toLowerCase();
+    if (lower.includes('commonredist')) return true;
+    if (/^_redist(\.|$)/i.test(filename)) return true;
+    return false;
+  } catch {
+    return false;
+  }
+}
+
 function isValidDownloadUrl(url) {
   const validDomains = [
     'mega.nz', 'mediafire.com', '1fichier.com', 'rapidgator.net',
@@ -1663,7 +1720,10 @@ function isValidDownloadUrl(url) {
     'buzzheavier.com', 'filecrypt.co', 'filecrypt.cc', 'up-4ever.net',
     'dayuploads.com', 'dlupload.com', 'file-upload.org', 'filespayouts.com',
     'swiftuploads.com', 'linkmix.co', 'pasteform.com', 'paste-form.com',
-    'file-me.top', 'loot-link.com', 'lootdest.org'
+    'file-me.top', 'loot-link.com', 'lootdest.org',
+    // Common on SteamRip / scene repacks
+    'workupload.com', 'send.cm', 'send.now', 'megadb.net', 'qiwi.gg',
+    'upload.ee', 'uploadnow.io', 'fuckingfast.net'
   ];
   
   try {

--- a/src/lib/gameapi/index.ts
+++ b/src/lib/gameapi/index.ts
@@ -8,6 +8,7 @@
 // TCP connect timeout. Per-request timeouts remain controlled by siteFetch().
 import './net';
 
+import { filterGamesBySearchQuery } from '../../utils/searchQueryFilter';
 import {
   SITE_CONFIGS as _SITE_CONFIGS,
   MAX_POSTS_PER_SITE as _MAX_POSTS_PER_SITE,
@@ -88,6 +89,10 @@ interface PostResult {
 // â”€â”€â”€ Search Cache â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 const searchCache = new Map<string, { results: TransformedPost[]; timestamp: number }>();
+
+function applySearchTermFilter(results: TransformedPost[], query: string): TransformedPost[] {
+  return filterGamesBySearchQuery(results, query);
+}
 const SEARCH_CACHE_TTL = 30 * 60 * 1000; // 30 minutes
 
 // â”€â”€â”€ Internal Helpers â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
@@ -217,7 +222,7 @@ export async function searchGames(query: string, site?: string): Promise<SearchR
       return { success: false, results: [], count: 0 };
     }
 
-    const results = await searchSite(siteConfig, query);
+    const results = applySearchTermFilter(await searchSite(siteConfig, query), query);
     const cacheKey = `${site}:${query.toLowerCase()}`;
 
     if (results.length > 0) {
@@ -225,7 +230,7 @@ export async function searchGames(query: string, site?: string): Promise<SearchR
     } else {
       // Retry once, then fallback to cache
       console.warn(`Single-site search for ${site} returned empty, retrying`);
-      const retryResults = await searchSite(siteConfig, query);
+      const retryResults = applySearchTermFilter(await searchSite(siteConfig, query), query);
       if (retryResults.length > 0) {
         searchCache.set(cacheKey, { results: retryResults, timestamp: Date.now() });
         return { success: true, results: retryResults, count: retryResults.length, site };
@@ -233,7 +238,8 @@ export async function searchGames(query: string, site?: string): Promise<SearchR
       const cached = searchCache.get(cacheKey);
       if (cached && (Date.now() - cached.timestamp) < SEARCH_CACHE_TTL) {
         console.log(`Using cached results for ${site}`);
-        return { success: true, results: cached.results, count: cached.results.length, site, cached: true };
+        const cachedFiltered = applySearchTermFilter(cached.results, query);
+        return { success: true, results: cachedFiltered, count: cachedFiltered.length, site, cached: true };
       }
     }
 
@@ -286,7 +292,8 @@ export async function searchGames(query: string, site?: string): Promise<SearchR
     });
   }
 
-  return { success: true, results: combinedResults, count: combinedResults.length };
+  const filteredCombined = applySearchTermFilter(combinedResults, query);
+  return { success: true, results: filteredCombined, count: filteredCombined.length };
 }
 
 /**

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -153,6 +153,38 @@ const userSchema = new mongoose.Schema({
       showRecentUploads: {
         type: Boolean,
         default: false
+      },
+      showAllGames: {
+        type: Boolean,
+        default: false
+      },
+      layoutMode: {
+        type: String,
+        enum: ['grid', 'horizontal'],
+        default: 'grid'
+      },
+      customCols: {
+        type: mongoose.Schema.Types.Mixed,
+        default: 'auto'
+      },
+      customRows: {
+        type: mongoose.Schema.Types.Mixed,
+        default: 'auto'
+      }
+    },
+    tracking: {
+      layoutMode: {
+        type: String,
+        enum: ['grid', 'horizontal'],
+        default: 'grid'
+      },
+      customCols: {
+        type: mongoose.Schema.Types.Mixed,
+        default: 'auto'
+      },
+      customRows: {
+        type: mongoose.Schema.Types.Mixed,
+        default: 'auto'
       }
     },
     releaseGroups: {

--- a/src/lib/trackedGameDownloadLinks.ts
+++ b/src/lib/trackedGameDownloadLinks.ts
@@ -2,6 +2,7 @@ import mongoose from 'mongoose';
 import connectDB from './db';
 import { getPostDetails } from './gameapi';
 import { TrackedGame } from './models';
+import { isDodiTrackedGame, isDodiSiteType } from './downloadSitePolicy';
 
 export type TrackedDownloadLink = {
   service: string;
@@ -15,6 +16,9 @@ export type TrackedDownloadLink = {
  * (Empty [] must not block fallback.)
  */
 export function collectStoredDownloadLinks(game: {
+  gameId?: string;
+  source?: string;
+  gameLink?: string;
   latestApprovedUpdate?: { downloadLinks?: TrackedDownloadLink[] };
   updateHistory?: Array<{
     dateFound?: string | Date;
@@ -22,6 +26,10 @@ export function collectStoredDownloadLinks(game: {
   }>;
   rssCachedDownloadLinks?: TrackedDownloadLink[];
 }): TrackedDownloadLink[] {
+  if (isDodiTrackedGame(game)) {
+    return [];
+  }
+
   const approved = game.latestApprovedUpdate?.downloadLinks;
   if (Array.isArray(approved) && approved.length > 0) {
     return approved.map(l => ({ ...l }));
@@ -120,7 +128,17 @@ export function isRssDownloadCacheStale(game: DownloadLinkSourceGame): boolean {
  * Omits `rssCachedDownloadLinks` when it is older than the latest update that introduced
  * download metadata (so a new game version does not keep showing links from the previous post).
  */
-export function mergeDownloadLinksForRss(game: DownloadLinkSourceGame): TrackedDownloadLink[] {
+export function mergeDownloadLinksForRss(
+  game: DownloadLinkSourceGame & {
+    gameId?: string;
+    source?: string;
+    gameLink?: string;
+  }
+): TrackedDownloadLink[] {
+  if (isDodiTrackedGame(game)) {
+    return [];
+  }
+
   const seen = new Set<string>();
   const out: TrackedDownloadLink[] = [];
 
@@ -218,11 +236,16 @@ export async function fetchDownloadLinksViaGameapi(
         else if (domain.includes('steamrip')) siteType = 'steamrip';
         else if (domain.includes('reloadedsteam')) siteType = 'reloadedsteam';
         else if (domain.includes('steamunderground')) siteType = 'steamunderground';
+        else if (domain.includes('dodi-repacks')) siteType = 'dodi';
       }
     }
   }
 
   if (!postId || !siteType) return [];
+
+  if (isDodiSiteType(siteType)) {
+    return [];
+  }
 
   try {
     const gameapiData = await getPostDetails(postId, siteType);
@@ -251,6 +274,10 @@ export async function syncRssDownloadLinksCache(trackedGameId: string): Promise<
 
   const game = await TrackedGame.findById(id).lean();
   if (!game) return false;
+
+  if (isDodiTrackedGame(game as GameapiGameShape)) {
+    return false;
+  }
 
   const links = await fetchDownloadLinksViaGameapi(game as GameapiGameShape);
   if (!links.length) return false;

--- a/src/utils/pagePreferences.ts
+++ b/src/utils/pagePreferences.ts
@@ -1,0 +1,154 @@
+export type LayoutMode = 'grid' | 'horizontal';
+export type GridSize = number | 'auto';
+export type PageKey = 'homepage' | 'tracking';
+
+export interface LayoutPreferences {
+  layoutMode: LayoutMode;
+  customCols: GridSize;
+  customRows: GridSize;
+}
+
+export interface HomepagePreferences extends LayoutPreferences {
+  showRecentUploads: boolean;
+  showAllGames: boolean;
+}
+
+export interface TrackingPreferences extends LayoutPreferences {}
+
+const COOKIE_KEYS: Record<PageKey, Record<string, string>> = {
+  homepage: {
+    layoutMode: 'homepageLayoutMode',
+    customCols: 'homepageCustomCols',
+    customRows: 'homepageCustomRows',
+    showRecentUploads: 'showRecentGames',
+    showAllGames: 'homepageShowAllGames',
+  },
+  tracking: {
+    layoutMode: 'trackingLayoutMode',
+    customCols: 'trackingCustomCols',
+    customRows: 'trackingCustomRows',
+  },
+};
+
+export function getCookie(name: string): string | null {
+  if (typeof document === 'undefined') return null;
+  const value = document.cookie
+    .split('; ')
+    .find(row => row.startsWith(`${name}=`))
+    ?.split('=')[1];
+  return value ? decodeURIComponent(value) : null;
+}
+
+export function setCookie(name: string, value: string, days = 365): void {
+  if (typeof document === 'undefined') return;
+  const expires = new Date();
+  expires.setTime(expires.getTime() + days * 24 * 60 * 60 * 1000);
+  document.cookie = `${name}=${encodeURIComponent(value)};expires=${expires.toUTCString()};path=/`;
+}
+
+export function parseGridSize(raw: string | null | undefined): GridSize {
+  if (!raw || raw === 'auto') return 'auto';
+  const n = Number(raw);
+  if (!Number.isNaN(n) && n >= 1 && n <= 12) return n;
+  return 'auto';
+}
+
+export function gridSizeToCookie(value: GridSize): string {
+  return value === 'auto' ? 'auto' : String(value);
+}
+
+export function parseLayoutMode(raw: string | null | undefined): LayoutMode {
+  return raw === 'horizontal' ? 'horizontal' : 'grid';
+}
+
+export function readLayoutFromCookies(page: PageKey): LayoutPreferences {
+  const keys = COOKIE_KEYS[page];
+  return {
+    layoutMode: parseLayoutMode(getCookie(keys.layoutMode)),
+    customCols: parseGridSize(getCookie(keys.customCols)),
+    customRows: parseGridSize(getCookie(keys.customRows)),
+  };
+}
+
+export function writeLayoutToCookies(page: PageKey, prefs: LayoutPreferences): void {
+  const keys = COOKIE_KEYS[page];
+  setCookie(keys.layoutMode, prefs.layoutMode);
+  setCookie(keys.customCols, gridSizeToCookie(prefs.customCols));
+  setCookie(keys.customRows, gridSizeToCookie(prefs.customRows));
+}
+
+export function readHomepageFromCookies(): HomepagePreferences {
+  const layout = readLayoutFromCookies('homepage');
+  const keys = COOKIE_KEYS.homepage;
+  return {
+    ...layout,
+    showRecentUploads: getCookie(keys.showRecentUploads) === 'true',
+    showAllGames: getCookie(keys.showAllGames) === 'true',
+  };
+}
+
+export function writeHomepageToCookies(prefs: Partial<HomepagePreferences>): void {
+  if (prefs.layoutMode !== undefined || prefs.customCols !== undefined || prefs.customRows !== undefined) {
+    writeLayoutToCookies('homepage', {
+      layoutMode: prefs.layoutMode ?? readLayoutFromCookies('homepage').layoutMode,
+      customCols: prefs.customCols ?? readLayoutFromCookies('homepage').customCols,
+      customRows: prefs.customRows ?? readLayoutFromCookies('homepage').customRows,
+    });
+  }
+  const keys = COOKIE_KEYS.homepage;
+  if (typeof prefs.showRecentUploads === 'boolean') {
+    // Short TTL for recent visibility (matches prior behavior)
+    setCookie(keys.showRecentUploads, prefs.showRecentUploads ? 'true' : 'false', 1 / 24);
+  }
+  if (typeof prefs.showAllGames === 'boolean') {
+    setCookie(keys.showAllGames, prefs.showAllGames ? 'true' : 'false');
+  }
+}
+
+export function buildCustomGridStyle(
+  layoutMode: LayoutMode,
+  customCols: GridSize,
+  customRows: GridSize
+): Record<string, string> | undefined {
+  if (layoutMode !== 'grid') return undefined;
+  const style: Record<string, string> = { display: 'grid', gap: '1rem' };
+  if (customCols !== 'auto') {
+    style.gridTemplateColumns = `repeat(${customCols}, minmax(0, 1fr))`;
+  }
+  if (customRows !== 'auto') {
+    style.gridTemplateRows = `repeat(${customRows}, minmax(0, 1fr))`;
+  }
+  return style;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function layoutFromDbRecord(raw: any): Partial<LayoutPreferences> | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const out: Partial<LayoutPreferences> = {};
+  if (raw.layoutMode === 'grid' || raw.layoutMode === 'horizontal') {
+    out.layoutMode = raw.layoutMode;
+  }
+  if (raw.customCols === 'auto' || raw.customCols === null || raw.customCols === undefined) {
+    out.customCols = 'auto';
+  } else {
+    const n = Number(raw.customCols);
+    if (!Number.isNaN(n) && n >= 1 && n <= 12) out.customCols = n;
+  }
+  if (raw.customRows === 'auto' || raw.customRows === null || raw.customRows === undefined) {
+    out.customRows = 'auto';
+  } else {
+    const n = Number(raw.customRows);
+    if (!Number.isNaN(n) && n >= 1 && n <= 12) out.customRows = n;
+  }
+  return Object.keys(out).length > 0 ? out : null;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function homepageFromDbRecord(raw: any): Partial<HomepagePreferences> | null {
+  const layout = layoutFromDbRecord(raw);
+  if (!raw || typeof raw !== 'object') return layout;
+  const out: Partial<HomepagePreferences> = { ...(layout || {}) };
+  if (typeof raw.showRecentUploads === 'boolean') out.showRecentUploads = raw.showRecentUploads;
+  if (typeof raw.showAllGames === 'boolean') out.showAllGames = raw.showAllGames;
+  return Object.keys(out).length > 0 ? out : null;
+}

--- a/src/utils/searchQueryFilter.ts
+++ b/src/utils/searchQueryFilter.ts
@@ -1,0 +1,46 @@
+/**
+ * Require every whitespace-separated token from the user's query to appear in
+ * a game's searchable text (original title, display title, excerpt, etc.).
+ */
+
+export type SearchableGameFields = {
+  title?: string;
+  originalTitle?: string;
+  excerpt?: string;
+  description?: string;
+};
+
+/** Split query into non-empty terms (preserves tokens like `0xdeadcode`). */
+export function parseSearchQueryTerms(query: string): string[] {
+  return String(query || '')
+    .toLowerCase()
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
+}
+
+export function getSearchableGameText(game: SearchableGameFields): string {
+  return [game.originalTitle, game.title, game.excerpt, game.description]
+    .filter((s): s is string => typeof s === 'string' && s.trim().length > 0)
+    .join(' ')
+    .toLowerCase();
+}
+
+export function gameMatchesAllSearchTerms(
+  game: SearchableGameFields,
+  terms: string[]
+): boolean {
+  if (terms.length === 0) return true;
+  const haystack = getSearchableGameText(game);
+  if (!haystack) return false;
+  return terms.every(term => haystack.includes(term));
+}
+
+export function filterGamesBySearchQuery<T extends SearchableGameFields>(
+  games: T[],
+  query: string
+): T[] {
+  const terms = parseSearchQueryTerms(query);
+  if (terms.length === 0) return games;
+  return games.filter(game => gameMatchesAllSearchTerms(game, terms));
+}


### PR DESCRIPTION
## Summary

Bundles multiple in-progress changes from local working tree into a single PR for review.

### Page layout preferences (per-account, persistent across logins/reloads/devices)
- New `PageLayoutSettings` component. Desktop panel is now **hidden by default**, revealed via a new "⚙️ Edit Layout" toggle button (previously the panel was always visible on desktop).
- New `pagePreferences` util + `usePersistedPagePreferences` hook + `/api/user/preferences` route for loading/saving layout state per account.
- Tracking page refactored to consume the shared layout component.
- `User.preferences` schema extended with layout fields.

### Game API + utilities
- Refinements to `games/search`, `games/links`, `games/downloads`, `updates/check` API routes.
- New `downloadSitePolicy` and `searchQueryFilter` utilities.
- Updates to `gameapi/helpers.js` and `trackedGameDownloadLinks` handling.
- Small `GamePosterCard` / `GameDownloadLinks` tweaks.

## Notes for reviewer

- This PR aggregates work that was sitting uncommitted on the local `main` branch — it is intentionally broad. Consider splitting per area if a more focused review is preferred.
- The visible behavioural change relevant to the most recent session: homepage layout panel is hidden by default and exposed via the new toggle button. Mobile flow is unchanged.

## Test plan

- [ ] Visit `/` while signed in: confirm layout panel is hidden by default and the "Edit Layout" button reveals it.
- [ ] Toggle layout / grid columns / rows; reload the page and confirm settings persist.
- [ ] Log in on a second device / browser; confirm the same layout settings load.
- [ ] Mobile view: confirm the existing `⚙️ Layout` modal still works unchanged.
- [ ] `/tracking` page: confirm shared layout component still renders correctly there.
- [ ] Smoke-test game search, refresh, recent uploads, and download-link expansion to validate the API/utility changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)