### PR TITLE
fix(lint): convert empty TrackingPreferences interface to type alias

### DIFF
--- a/src/utils/pagePreferences.ts
+++ b/src/utils/pagePreferences.ts
@@ -13,7 +13,7 @@ export interface HomepagePreferences extends LayoutPreferences {
   showAllGames: boolean;
 }
 
-export interface TrackingPreferences extends LayoutPreferences {}
+export type TrackingPreferences = LayoutPreferences;
 
 const COOKIE_KEYS: Record<PageKey, Record<string, string>> = {
   homepage: {


### PR DESCRIPTION
Fixes @typescript-eslint/no-empty-object-type lint error that broke the production Docker build.