### PR TITLE
feat(prefs): avoidRepacks also filters DODI / FitGirl source posts

### DIFF
--- a/src/app/api/tracking/custom/route.ts
+++ b/src/app/api/tracking/custom/route.ts
@@ -8,6 +8,7 @@ import { updateScheduler } from '../../../../lib/scheduler';
 import { syncRssDownloadLinksCache } from '../../../../lib/trackedGameDownloadLinks';
 import { analyzeGameTitle } from '../../../../utils/versionDetection';
 import { searchIGDB, type IGDBSearchResult } from '../../../../utils/igdb';
+import { isRepackPost } from '../../../../lib/repackFilter';
 import logger from '../../../../utils/logger';
 import { rateLimit, validateInput, schemas } from '../../../../utils/validation';
 import { searchGames } from '../../../../lib/gameapi';
@@ -127,14 +128,15 @@ export async function POST(req: NextRequest) {
 
       // First try piracy sites
       if (searchData.success && searchData.results && searchData.results.length > 0) {
-        // Filter out repacks if user preference is enabled
+        // Filter out repacks if user preference is enabled. Catches both
+        // title-based ("...repack...") and source-based (DODI / FitGirl)
+        // repacks via the shared helper.
         let filteredResults = searchData.results;
         if (releaseGroupPreferences.avoidRepacks) {
           const originalCount = filteredResults.length;
-          filteredResults = filteredResults.filter((game: { title: string }) => {
-            const title = game.title.toLowerCase();
-            return !title.includes('repack') && !title.includes('-repack');
-          });
+          filteredResults = filteredResults.filter(
+            (game: { title: string; siteType?: string }) => !isRepackPost(game, true),
+          );
           const filteredCount = originalCount - filteredResults.length;
           if (filteredCount > 0) {
             logger.info(`Filtered out ${filteredCount} repack(s) from custom game search for "${trimmedGameName}"`);

--- a/src/app/api/updates/check/route.ts
+++ b/src/app/api/updates/check/route.ts
@@ -8,6 +8,7 @@ import { sendUpdateNotification, createUpdateNotificationData } from '../../../.
 import { cleanGameTitle, decodeHtmlEntities, extractReleaseGroup, is0xdeadcodeRelease, isOnlineFixRelease, resolveComparableVersionData, resolvePubTimestampFromBuild, resolvePubTimestampFromVersion } from '../../../../utils/steamApi';
 import logger from '../../../../utils/logger';
 import { getPostDetails, getRecentUploads, clearGameApiCache } from '../../../../lib/gameapi';
+import { isRepackPost } from '../../../../lib/repackFilter';
 import { syncRssDownloadLinksCache } from '../../../../lib/trackedGameDownloadLinks';
 
 import { calculateGameSimilarity } from '../../../../utils/titleMatching';
@@ -754,13 +755,15 @@ export async function POST(request: Request) {
       const recentData = await getRecentUploads();
       recentGames = recentData.results || [];
         
-      // Filter out repacks if user preference is set
+      // Filter out repacks if user preference is set. Catches both
+      // title-based ("...repack...") and source-based (DODI / FitGirl)
+      // repacks - previously only the title check ran so a FitGirl post
+      // for "Cyberpunk 2077" still passed through.
       if (releaseGroupPreferences.avoidRepacks) {
         const originalCount = recentGames.length;
-        recentGames = recentGames.filter((game: GameSearchResult) => {
-          const title = game.title.toLowerCase();
-          return !title.includes('repack') && !title.includes('-repack');
-        });
+        recentGames = recentGames.filter(
+          (game: GameSearchResult) => !isRepackPost(game, true),
+        );
         const filtered = originalCount - recentGames.length;
         if (filtered > 0) {
           logger.info(`Filtered out ${filtered} repack(s) based on user preference`);

--- a/src/app/user/manage/page.tsx
+++ b/src/app/user/manage/page.tsx
@@ -421,7 +421,7 @@ export default function UserManagePage() {
                     Avoid Repacks
                   </label>
                   <p className="text-xs text-gray-600 dark:text-gray-400 mt-1">
-                    Filter out repack releases (titles containing &quot;repack&quot; or &quot;-repack&quot;) from update notifications
+                    Filter out repack releases from update notifications. Drops posts whose titles contain &quot;repack&quot; / &quot;-repack&quot; AND posts from repack-focused sources (DODI, FitGirl).
                   </p>
                 </div>
               </div>

--- a/src/lib/repackFilter.ts
+++ b/src/lib/repackFilter.ts
@@ -1,0 +1,36 @@
+/**
+ * "Avoid repacks" filter shared by every endpoint that respects the user's
+ * `releaseGroups.avoidRepacks` preference. Catches repacks two ways:
+ *
+ *   1. Title substring - some scene-site posts include "repack" / "-repack"
+ *      in the title (the original heuristic).
+ *   2. Source site - DODI and FitGirl are repack distributors by design;
+ *      every post they publish is a repack regardless of how the title
+ *      reads. Without this, e.g. a FitGirl post for "Cyberpunk 2077" still
+ *      makes it through because the title doesn't contain "repack".
+ */
+
+const REPACK_SITE_TYPES = new Set<string>(['dodi', 'fitgirl']);
+
+export function isRepackSiteType(siteType: string | null | undefined): boolean {
+  return REPACK_SITE_TYPES.has((siteType || '').trim().toLowerCase());
+}
+
+function titleLooksLikeRepack(title: string | null | undefined): boolean {
+  if (!title) return false;
+  const t = title.toLowerCase();
+  return t.includes('repack') || t.includes('-repack');
+}
+
+/**
+ * Returns true when this post should be dropped because the user has opted
+ * to avoid repacks. Pass `avoidRepacks=false` and you'll always get false -
+ * no need to guard the call site.
+ */
+export function isRepackPost(
+  post: { title?: string | null; siteType?: string | null },
+  avoidRepacks: boolean,
+): boolean {
+  if (!avoidRepacks) return false;
+  return titleLooksLikeRepack(post.title) || isRepackSiteType(post.siteType);
+}


### PR DESCRIPTION
The user's "Avoid Repacks" preference previously only fired on titles containing "repack" / "-repack". Posts from repack distributors that didn't happen to mention "repack" in the title (e.g. a FitGirl post titled "Cyberpunk 2077 - v2.21 + DLCs", or any DODI post) passed through. Since DODI and FitGirl ARE repack distributors by design, every post they publish is a repack regardless of title shape.

Adds src/lib/repackFilter.ts with isRepackPost({title, siteType}, avoidRepacks) that combines:
- the existing title substring check
- a new check against REPACK_SITE_TYPES = {dodi, fitgirl}

Wired into both existing call sites that already honored the preference:
- src/app/api/updates/check/route.ts (recent-uploads filter)
- src/app/api/tracking/custom/route.ts (custom-tracking search)

UI description updated to reflect the broader behavior.

Note on scope: the search and recent home-page routes still don't apply avoidRepacks at all - that's pre-existing and a separate concern. This commit only fixes the two places that already honored the preference but were doing so too narrowly.